### PR TITLE
legg til servicebruker i statistikk til analyseformål

### DIFF
--- a/app/src/main/resources/migrering/V0.27__legg_til_servicebruker_analyse.sql
+++ b/app/src/main/resources/migrering/V0.27__legg_til_servicebruker_analyse.sql
@@ -1,0 +1,7 @@
+GRANT
+SELECT
+    ON ALL TABLES IN SCHEMA public to cloudsqliamserviceaccount;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT
+SELECT
+    ON TABLES TO cloudsqliamserviceaccount;

--- a/app/src/main/resources/migrering/V0.28__legg_til_servicebruker_analyse.sql
+++ b/app/src/main/resources/migrering/V0.28__legg_til_servicebruker_analyse.sql
@@ -1,3 +1,6 @@
+-- PS, hopper spesifikt over versjon 0.27, for den ligger i test-scope for å opprette
+-- cloudsqliamserviceaccount-rollen, som allerede finnes i GCP.
+
 GRANT
 SELECT
     ON ALL TABLES IN SCHEMA public to cloudsqliamserviceaccount;

--- a/app/src/test/resources/migrering/V0.27__cloudsqliamuser.sql
+++ b/app/src/test/resources/migrering/V0.27__cloudsqliamuser.sql
@@ -1,0 +1,15 @@
+-- V0.27__cloudsqliamuser.sql brukes til å opprette ting som finnes på GCP.
+DROP ROLE IF EXISTS cloudsqliamuser;
+CREATE ROLE cloudsqliamuser;
+
+
+DO
+$$
+    BEGIN
+        IF NOT EXISTS (SELECT
+                       FROM pg_catalog.pg_roles
+                       WHERE rolname = 'cloudsqliamserviceaccount') THEN
+            CREATE ROLE cloudsqliamserviceaccount;
+        END IF;
+    END
+$$;


### PR DESCRIPTION
For å oppdatere Kelvin-dashboardet i Team AAP trenger vi nå uttrekk fra statistikk-databasen. 

Jeg har prøvd å legge til servicebruker slik jeg gjorde i denne PRen for postmottak https://github.com/navikt/aap-postmottak-backend/pull/205 men jeg finner ikke riktig sted å opprette servicebrukeren. 

Vi trenger begge disse SQL-jobbene. Hvor bør de legges i appen?

Opprette rolletilgang for servicebruker

```sql 
CREATE ROLE cloudsqliamuser;

DROP ROLE IF EXISTS cloudsqliamserviceaccount;
CREATE ROLE cloudsqliamserviceaccount;
```

Gi servicebruker tilgang

```sql
GRANT
SELECT
    ON ALL TABLES IN SCHEMA public to cloudsqliamserviceaccount;

ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT
SELECT
    ON TABLES TO cloudsqliamserviceaccount;
```