### PR TITLE
Fiks krasj ved resending av hendelse med diagnose

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImpl.kt
@@ -42,7 +42,11 @@ VALUES ((SELECT b.id
          WHERE br.referanse = ?),
         ?,
         ?,
-        ?);
+        ?)
+ON CONFLICT (behandling_id) DO UPDATE SET
+    kodeverk = EXCLUDED.kodeverk,
+    diagnosekode = EXCLUDED.diagnosekode,
+    bidiagnoser = EXCLUDED.bidiagnoser;
 
         """.trimIndent()
 

--- a/app/src/test/kotlin/no/nav/aap/statistikk/IntegrationTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/IntegrationTest.kt
@@ -248,7 +248,7 @@ class IntegrationTest {
             azureConfig = azureConfig,
         ) {
             oppdatertBehandlingHendelse(avsluttetBehandlingHendelser.last().data)
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
         }
 
         val alleSakstatistikkHendelser = dataSource.transaction {
@@ -442,7 +442,7 @@ class IntegrationTest {
         fun verifiserHendelseRekkefølge(
             expectedValues: List<Triple<String?, String?, BehandlingMetode>>
         ) {
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
             val alleSakstatistikkHendelser = dataSource.transaction {
                 SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(behandlingReferanse)
             }
@@ -882,7 +882,7 @@ class IntegrationTest {
         ) {
             postBehandlingsflytHendelse(hendelsx)
 
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
 
             val gjeldendeAVklaringsbehov =
                 dataSource.transaction { BehandlingRepository(it).hent(hendelse.behandlingReferanse)!!.gjeldendeAvklaringsBehov }!!
@@ -909,11 +909,11 @@ class IntegrationTest {
                     )
                 )
             )
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
 
             postBehandlingsflytHendelse(hendelse)
 
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
             val behandling = ventPåSvar(
                 {
                     dataSource.transaction {
@@ -930,7 +930,7 @@ class IntegrationTest {
             }
             assertThat(enhet.enhet).isEqualTo("0400")
 
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
             val bqSaker = hentSakstatistikkHendelserMedEksaktAntall(
                 dataSource, behandling!!.referanse
             )
@@ -945,7 +945,7 @@ class IntegrationTest {
                 )
             )
 
-            testUtil.ventPåSvar()
+            ventPåSvarEllerFeil(dataSource)
 
             // Sekvensnummer økes med 1 med ny info på sak
             val bqSaker2 = dataSource.transaction {
@@ -1023,12 +1023,12 @@ class IntegrationTest {
                 is BehandlingHendelseData -> {
                     postBehandlingsflytHendelse(it.data)
                     referanse = it.data.behandlingReferanse
-                    testUtil.ventPåSvar()
+                    ventPåSvarEllerFeil(dataSource)
                 }
 
                 is OppgaveHendelseData -> {
                     postOppgaveHendelse(dataSource, it.data)
-                    testUtil.ventPåSvar()
+                    ventPåSvarEllerFeil(dataSource)
                 }
 
                 is OppgaveHendelseAPIData -> postOppgaveData(it.data)
@@ -1038,7 +1038,7 @@ class IntegrationTest {
 
         val feilende = dataSource.transaction { DriftJobbRepositoryExposed(it).hentAlleFeilende() }
         log.info("Feilende jobber: $feilende")
-        testUtil.ventPåSvar()
+        ventPåSvarEllerFeil(dataSource)
 
         val behandling = ventPåSvar(
             { dataSource.transaction { BehandlingRepository(it).hent(referanse!!) } },

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -31,6 +31,8 @@ import no.nav.aap.komponenter.repository.RepositoryProvider
 import no.nav.aap.komponenter.type.Periode
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.Motor
+import no.nav.aap.motor.retry.DriftJobbRepositoryExposed
+import no.nav.aap.motor.testutil.TestJobbRepository
 import no.nav.aap.oppgave.statistikk.OppgaveHendelse
 import no.nav.aap.postmottak.kontrakt.hendelse.DokumentflytStoppetHendelse
 import no.nav.aap.statistikk.AppConfig
@@ -850,6 +852,35 @@ fun <E> ventPåSvar(getter: () -> E?, predicate: (E?) -> Boolean): E? {
         logger.info("Ventet på svar, men svaret er null.")
     }
     return res
+}
+
+/**
+ * Venter til alle jobber er ferdige, men avbryter umiddelbart hvis noen jobber feiler.
+ * Forhindrer lang ventetid i integrasjonstester ved uventede jobbkrasj.
+ */
+fun ventPåSvarEllerFeil(
+    dataSource: DataSource,
+    cronJobberSomSkalIgnoreres: List<String> = listOf("oppgave.retryFeilede"),
+    maxTidSekunder: Long = 20,
+) {
+    val sluttTidspunkt = LocalDateTime.now().plusSeconds(maxTidSekunder)
+    while (LocalDateTime.now().isBefore(sluttTidspunkt)) {
+        val (feilende, harVentende) = dataSource.transaction(readOnly = true) { connection ->
+            val feilende = DriftJobbRepositoryExposed(connection).hentAlleFeilende()
+            val harVentende = TestJobbRepository(connection, cronJobberSomSkalIgnoreres).harJobb(null, null)
+            Pair(feilende, harVentende)
+        }
+
+        if (feilende.isNotEmpty()) {
+            val detaljer = feilende.joinToString("\n") { (jobb, melding) -> "  ${jobb.type()}: $melding" }
+            throw AssertionError("${feilende.size} jobber feilet:\n$detaljer")
+        }
+
+        if (!harVentende) return
+
+        Thread.sleep(50)
+    }
+    throw AssertionError("Timeout: jobber ikke ferdig etter $maxTidSekunder sekunder")
 }
 
 fun forberedDatabase(


### PR DESCRIPTION
## Problem

`DiagnoseRepositoryImpl.lagre()` brukte en enkel `INSERT` uten konflikthåndtering. Ved resending av en allerede behandlet hendelse forsøkte bakgrunnsjobben `statistikk.lagreHendelse` å sette inn en ny rad i `DIAGNOSE`-tabellen for en `behandling_id` som allerede eksisterte:

```
PSQLException: ERROR: duplicate key value violates unique constraint "uid_diagnose_behandling"
Detail: Key (behandling_id)=(X) already exists.
```

Stack trace:
```
DiagnoseRepositoryImpl.lagre(DiagnoseRepositoryImpl.kt:49)
AvsluttetBehandlingService.lagreDiagnose(AvsluttetBehandlingService.kt:91)
AvsluttetBehandlingService.lagre(AvsluttetBehandlingService.kt:31)
HendelsesService.prosesserNyHendelse(HendelsesService.kt:50)
LagreStoppetHendelseJobbUtfører.utfør(...)
```

Feilen oppstår fordi `AvsluttetBehandlingService.lagre()` alltid kaller `lagreDiagnose()`, også ved resending.

## Fix

Bytter til `INSERT ... ON CONFLICT (behandling_id) DO UPDATE SET ...` slik at eksisterende diagnose oppdateres istedenfor å kaste feil.