### PR TITLE
Bruk ManuellMotorImpl i MottaStatistikkTest for raskere tester

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
@@ -169,6 +169,7 @@ fun Application.startUp(
         azureConfig,
         motorApiCallback,
         lagreStoppetHendelseJobb,
+        lagreAvklaringsbehovHendelseJobb,
     )
 }
 
@@ -199,6 +200,7 @@ fun Application.module(
     azureConfig: AzureConfig,
     motorApiCallback: NormalOpenAPIRoute.() -> Unit,
     lagreStoppetHendelseJobb: LagreStoppetHendelseJobb,
+    lagreAvklaringsbehovHendelseJobb: LagreAvklaringsbehovHendelseJobb,
 ) {
     transactionExecutor.withinTransaction {
         RetryService(it).enable()
@@ -227,6 +229,7 @@ fun Application.module(
                 mottaOppdatertBehandling(
                     transactionExecutor,
                     jobbAppender,
+                    lagreAvklaringsbehovHendelseJobb,
                 )
                 mottaOppgaveOppdatering(transactionExecutor, jobbAppender)
                 mottaPostmottakOppdatering(

--- a/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
@@ -93,7 +93,10 @@ fun Application.startUp(
     dbConfig: DbConfig,
     azureConfig: AzureConfig,
     bigQueryClientYtelse: IBigQueryClient,
-    gatewayProvider: GatewayProvider
+    gatewayProvider: GatewayProvider,
+    motorFactory: (DataSource, GatewayProvider, List<JobbSpesifikasjon>) -> Motor = { ds, gp, jobber ->
+        motor(ds, gp, jobber)
+    },
 ) {
     log.info("Starter.")
 
@@ -118,21 +121,19 @@ fun Application.startUp(
     val lagrePostmottakHendelseJobb = LagrePostmottakHendelseJobb()
     val resendSakstatistikkJobb = ResendSakstatistikkJobb()
 
-    val motor = motor(
-        dataSource,
-        gatewayProvider,
-        listOf(
-            lagreStoppetHendelseJobb,
-            lagreAvklaringsbehovHendelseJobb,
-            lagreOppgaveHendelseJobb,
-            lagrePostmottakHendelseJobb,
-            lagreSakinfoTilBigQueryJobb,
-            lagreAvsluttetBehandlingTilBigQueryJobb,
-            lagreOppgaveJobb,
-            resendSakstatistikkJobb,
-            LagreTilbakekrevingHendelseJobb()
-        )
+    val jobberListe = listOf(
+        lagreStoppetHendelseJobb,
+        lagreAvklaringsbehovHendelseJobb,
+        lagreOppgaveHendelseJobb,
+        lagrePostmottakHendelseJobb,
+        lagreSakinfoTilBigQueryJobb,
+        lagreAvsluttetBehandlingTilBigQueryJobb,
+        lagreOppgaveJobb,
+        resendSakstatistikkJobb,
+        LagreTilbakekrevingHendelseJobb()
     )
+
+    val motor = motorFactory(dataSource, gatewayProvider, jobberListe)
 
     monitor.subscribe(ApplicationStarted) {
         log.info("Ktor-hendelse: ApplicationStarted.")

--- a/app/src/main/kotlin/no/nav/aap/statistikk/api/mottaStatistikk.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/api/mottaStatistikk.kt
@@ -101,13 +101,14 @@ fun NormalOpenAPIRoute.mottaTilbakekrevingshendelse(
 fun NormalOpenAPIRoute.mottaOppdatertBehandling(
     transactionExecutor: TransactionExecutor,
     jobbAppender: JobbAppender,
+    lagreAvklaringsbehovHendelseJobb: LagreAvklaringsbehovHendelseJobb,
 ) {
     mottaHendelse<StoppetBehandling>(
         path = "/oppdatertBehandling",
         authorizedAzps = listOf(Azp.Behandlingsflyt.uuid),
         transactionExecutor = transactionExecutor,
         jobbAppender = jobbAppender,
-        jobbSpesifikasjon = LagreAvklaringsbehovHendelseJobb(jobbAppender),
+        jobbSpesifikasjon = lagreAvklaringsbehovHendelseJobb,
         saksnummer = { stringToNumber(it.saksnummer) },
     )
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/GenererOpenApiJson.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/GenererOpenApiJson.kt
@@ -47,6 +47,7 @@ fun main() {
             azureConfig = azureConfig,
             motorApiCallback = { },
             lagreStoppetHendelseJobb = mockk(),
+            lagreAvklaringsbehovHendelseJobb = mockk(),
         )
     }.start()
 

--- a/app/src/test/kotlin/no/nav/aap/statistikk/IntegrationTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/IntegrationTest.kt
@@ -16,7 +16,7 @@ import no.nav.aap.komponenter.json.DefaultJsonMapper
 import no.nav.aap.motor.FlytJobbRepository
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.retry.DriftJobbRepositoryExposed
-import no.nav.aap.motor.testutil.TestUtil
+import no.nav.aap.motor.testutil.ManuellMotorImpl
 import no.nav.aap.oppgave.statistikk.HendelseType
 import no.nav.aap.oppgave.statistikk.OppgaveTilStatistikkDto
 import no.nav.aap.oppgave.verdityper.Behandlingstype
@@ -127,19 +127,18 @@ class IntegrationTest {
                 .filter { it.data.avsluttetBehandling != null }
         assertThat(avsluttetBehandlingHendelser).hasSize(1)
 
-        val testUtil = setupTestEnvironment(dataSource)
         lateinit var referanse: UUID
-        testKlientNoInjection(
+        testKlientNoInjectionManuell(
             dbConfig,
             azureConfig = azureConfig,
-        ) {
+        ) { motor ->
             referanse = prosesserHendelserOgVerifiserBehandling(
-                dataSource, hendelserFraDBDump, testUtil
+                dataSource, hendelserFraDBDump, motor
             )
         }
 
         // Sekvensnummer økes med 1 med ny info på sak
-        val bqSaker = hentSakstatistikkHendelser(dataSource, referanse)!!
+        val bqSaker = hentSakstatistikkHendelser(dataSource, referanse)
 
         assertThat(bqSaker).extracting(
             "ansvarligEnhetKode",
@@ -213,10 +212,10 @@ class IntegrationTest {
         )
 
         // Sjekk tilkjent ytelse
-        val tilkjentYtelse = ventPåSvar(
-            { dataSource.transaction { TilkjentYtelseRepository(it).hentForBehandling(referanse)?.perioder } },
-            { t -> t !== null && t.isNotEmpty() })
+        val tilkjentYtelse = dataSource.transaction { TilkjentYtelseRepository(it).hentForBehandling(referanse)?.perioder }
 
+        assertThat(tilkjentYtelse).isNotNull
+        assertThat(tilkjentYtelse).isNotEmpty
         assertThat(tilkjentYtelse!!).allSatisfy {
             assertThat(it.dagsats).isEqualTo(974.0)
             assertThat(it.antallBarn).isEqualTo(1)
@@ -243,12 +242,12 @@ class IntegrationTest {
 
         println("RESENDING")
         // DEL 2: test resending
-        testKlientNoInjection(
+        testKlientNoInjectionManuell(
             dbConfig,
             azureConfig = azureConfig,
-        ) {
+        ) { motor ->
             oppdatertBehandlingHendelse(avsluttetBehandlingHendelser.last().data)
-            ventPåSvarEllerFeil(dataSource)
+            motor.kjørJobber()
         }
 
         val alleSakstatistikkHendelser = dataSource.transaction {
@@ -365,22 +364,21 @@ class IntegrationTest {
             .sortedBy { it.opprettetTidspunkt }
 
 
-        val testUtil = setupTestEnvironment(dataSource)
-        testKlientNoInjection(
+        testKlientNoInjectionManuell(
             dbConfig,
             azureConfig = azureConfig,
             FakeBigQueryClient,
-        ) {
+        ) { motor ->
 
             prosesserHendelserOgVerifiserBehandling(
-                dataSource, behandlingHendelser, testUtil
+                dataSource, behandlingHendelser, motor
             )
         }
 
         // Sekvensnummer økes med 1 med ny info på sak
         val bqSaker2 = hentSakstatistikkHendelser(dataSource, referanse)
 
-        assertThat(bqSaker2!!.map { it.behandlingStatus }).containsSubsequence(
+        assertThat(bqSaker2.map { it.behandlingStatus }).containsSubsequence(
             "OPPRETTET",
             "UNDER_BEHANDLING",
             "IVERKSETTES",
@@ -394,8 +392,6 @@ class IntegrationTest {
         @Postgres dataSource: DataSource,
         @Fakes azureConfig: AzureConfig,
     ) {
-        val testUtil = setupTestEnvironment(dataSource)
-
         val behandlingReferanse = UUID.fromString("ca0a378d-9249-47b3-808a-afe6a6357ac5")
         val personIdent = "2718281828"
         val saksnummer = "ABCDE"
@@ -439,37 +435,37 @@ class IntegrationTest {
             søknadIder = emptyList()
         )
 
-        fun verifiserHendelseRekkefølge(
-            expectedValues: List<Triple<String?, String?, BehandlingMetode>>
-        ) {
-            ventPåSvarEllerFeil(dataSource)
-            val alleSakstatistikkHendelser = dataSource.transaction {
-                SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(behandlingReferanse)
-            }
+        testKlientNoInjectionManuell(dbConfig, azureConfig = azureConfig) { motor ->
+            fun verifiserHendelseRekkefølge(
+                expectedValues: List<Triple<String?, String?, BehandlingMetode>>
+            ) {
+                motor.kjørJobber()
+                val alleSakstatistikkHendelser = dataSource.transaction {
+                    SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(behandlingReferanse)
+                }
 
-            println("...")
-            alleSakstatistikkHendelser.forEach {
-                println(
-                    String.format(
-                        "%-15s %-15s %-15s",
-                        it.ansvarligEnhetKode,
-                        it.saksbehandler,
-                        it.behandlingMetode.name
+                println("...")
+                alleSakstatistikkHendelser.forEach {
+                    println(
+                        String.format(
+                            "%-15s %-15s %-15s",
+                            it.ansvarligEnhetKode,
+                            it.saksbehandler,
+                            it.behandlingMetode.name
+                        )
                     )
-                )
+                }
+                println("...")
+
+                assertThat(alleSakstatistikkHendelser)
+                    .extracting("ansvarligEnhetKode", "saksbehandler", "behandlingMetode")
+                    .containsExactly(
+                        *expectedValues.map { (enhet, saksbehandler, metode) ->
+                            tuple(enhet, saksbehandler, metode)
+                        }.toTypedArray()
+                    )
             }
-            println("...")
 
-            assertThat(alleSakstatistikkHendelser)
-                .extracting("ansvarligEnhetKode", "saksbehandler", "behandlingMetode")
-                .containsExactly(
-                    *expectedValues.map { (enhet, saksbehandler, metode) ->
-                        tuple(enhet, saksbehandler, metode)
-                    }.toTypedArray()
-                )
-        }
-
-        testKlientNoInjection(dbConfig, azureConfig = azureConfig) {
             postBehandlingsflytHendelse(initialBehandlingHendelse)
 
             val førsteHendelser = listOf(
@@ -875,14 +871,13 @@ class IntegrationTest {
             hendelsesTidspunkt = hendelse.hendelsesTidspunkt.minusMinutes(5)
         )
 
-        val testUtil = TestUtil(dataSource, listOf("oppgave.retryFeilede"))
-        testKlientNoInjection(
+        testKlientNoInjectionManuell(
             dbConfig,
             azureConfig = azureConfig
-        ) {
+        ) { motor ->
             postBehandlingsflytHendelse(hendelsx)
 
-            ventPåSvarEllerFeil(dataSource)
+            motor.kjørJobber()
 
             val gjeldendeAVklaringsbehov =
                 dataSource.transaction { BehandlingRepository(it).hent(hendelse.behandlingReferanse)!!.gjeldendeAvklaringsBehov }!!
@@ -909,18 +904,14 @@ class IntegrationTest {
                     )
                 )
             )
-            ventPåSvarEllerFeil(dataSource)
+            motor.kjørJobber()
 
             postBehandlingsflytHendelse(hendelse)
 
-            ventPåSvarEllerFeil(dataSource)
-            val behandling = ventPåSvar(
-                {
-                    dataSource.transaction {
-                        BehandlingRepository(it).hent(behandlingReferanse)
-                    }
-                },
-                { it != null })
+            motor.kjørJobber()
+            val behandling = dataSource.transaction {
+                BehandlingRepository(it).hent(behandlingReferanse)
+            }
             assertThat(behandling).isNotNull
             val enhet = dataSource.transaction {
                 OppgaveHendelseRepositoryImpl(it).hentEnhetOgReservasjonForAvklaringsbehov(
@@ -930,13 +921,12 @@ class IntegrationTest {
             }
             assertThat(enhet.enhet).isEqualTo("0400")
 
-            ventPåSvarEllerFeil(dataSource)
             val bqSaker = hentSakstatistikkHendelserMedEksaktAntall(
                 dataSource, behandling!!.referanse
             )
-            assertThat(bqSaker).isNotNull
+            assertThat(bqSaker).isNotEmpty
 //            assertThat(bqSaker).hasSize(5)  // Nå får vi også en retroaktiv oppdatering
-            assertThat(bqSaker!!.first().sekvensNummer).isEqualTo(1)
+            assertThat(bqSaker.first().sekvensNummer).isEqualTo(1)
 
             postBehandlingsflytHendelse(
                 hendelse.copy(
@@ -945,7 +935,7 @@ class IntegrationTest {
                 )
             )
 
-            ventPåSvarEllerFeil(dataSource)
+            motor.kjørJobber()
 
             // Sekvensnummer økes med 1 med ny info på sak
             val bqSaker2 = dataSource.transaction {
@@ -954,47 +944,29 @@ class IntegrationTest {
 //            assertThat(bqSaker2).hasSize(5)
             assertThat(bqSaker2[1].sekvensNummer).isEqualTo(2)
 
-            val vilkårRespons = ventPåSvar(
-                {
-                    dataSource.transaction {
-                        VilkårsresultatRepository(it).hentForBehandling(
-                            behandlingReferanse
-                        )
-                    }.vilkår
-                },
-                { t -> t !== null && t.isNotEmpty() })
+            val vilkårRespons = dataSource.transaction {
+                VilkårsresultatRepository(it).hentForBehandling(behandlingReferanse)
+            }.vilkår
 
             assertThat(vilkårRespons).hasSize(9)
             val vilkårsVurderingRad = vilkårRespons!!.first()
 
             assertThat(vilkårsVurderingRad.vilkårType).isEqualTo(Vilkårtype.ALDERSVILKÅRET.name)
 
-            val tilkjent = ventPåSvar(
-                {
-                    dataSource.transaction {
-                        TilkjentYtelseRepository(it).hentForBehandling(
-                            behandlingReferanse
-                        )!!.perioder
-                    }
-                },
-                { t -> t !== null && t.isNotEmpty() })
+            val tilkjent = dataSource.transaction {
+                TilkjentYtelseRepository(it).hentForBehandling(behandlingReferanse)!!.perioder
+            }
 
-            assertThat(tilkjent!!).hasSize(1)
+            assertThat(tilkjent).hasSize(1)
             val tilkjentYtelse = tilkjent.first()
             assertThat(tilkjentYtelse.dagsats).isEqualTo(hendelse.avsluttetBehandling!!.tilkjentYtelse.perioder[0].dagsats)
 
-            val sakRespons = ventPåSvar(
-                {
-                    dataSource.transaction {
-                        SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(
-                            behandlingReferanse
-                        )
-                    }
-                },
-                { t -> t !== null && t.isNotEmpty() })
+            val sakRespons = dataSource.transaction {
+                SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(behandlingReferanse)
+            }
 
 //            assertThat(sakRespons).hasSize(4)
-            sakRespons!!.forEach { println(it) }
+            sakRespons.forEach { println(it) }
 //            assertThat(sakRespons.first().saksbehandler).isEqualTo("VEILEDER")
             assertThat(sakRespons).anyMatch { it.vedtakTidTrunkert != null }
             assertThat(sakRespons.last().vedtakTidTrunkert).isEqualTo(
@@ -1003,17 +975,13 @@ class IntegrationTest {
         }
     }
 
-    private fun setupTestEnvironment(
-        dataSource: DataSource
-    ): TestUtil {
-        val testUtil = TestUtil(dataSource, listOf("oppgave.retryFeilede"))
-        return testUtil
+    private fun setupTestEnvironment(dataSource: DataSource) {
     }
 
     private fun TestClient.prosesserHendelserOgVerifiserBehandling(
         dataSource: DataSource,
         hendelser: List<HendelseData>,
-        testUtil: TestUtil,
+        motor: ManuellMotorImpl,
         expectedStatus: BehandlingStatus = BehandlingStatus.AVSLUTTET
     ): UUID {
         var referanse: UUID? = null
@@ -1023,12 +991,12 @@ class IntegrationTest {
                 is BehandlingHendelseData -> {
                     postBehandlingsflytHendelse(it.data)
                     referanse = it.data.behandlingReferanse
-                    ventPåSvarEllerFeil(dataSource)
+                    motor.kjørJobber()
                 }
 
                 is OppgaveHendelseData -> {
                     postOppgaveHendelse(dataSource, it.data)
-                    ventPåSvarEllerFeil(dataSource)
+                    motor.kjørJobber()
                 }
 
                 is OppgaveHendelseAPIData -> postOppgaveData(it.data)
@@ -1038,12 +1006,9 @@ class IntegrationTest {
 
         val feilende = dataSource.transaction { DriftJobbRepositoryExposed(it).hentAlleFeilende() }
         log.info("Feilende jobber: $feilende")
-        ventPåSvarEllerFeil(dataSource)
+        motor.kjørJobber()
 
-        val behandling = ventPåSvar(
-            { dataSource.transaction { BehandlingRepository(it).hent(referanse!!) } },
-            { it != null }
-        )
+        val behandling = dataSource.transaction { BehandlingRepository(it).hent(referanse!!) }
 
         assertThat(behandling!!.behandlingStatus()).isEqualTo(expectedStatus)
         return referanse!!
@@ -1052,26 +1017,16 @@ class IntegrationTest {
     private fun hentSakstatistikkHendelser(
         dataSource: DataSource,
         referanse: UUID
-    ) = ventPåSvar(
-        {
-            dataSource.transaction {
-                SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(referanse)
-            }
-        },
-        { t -> t !== null && t.isNotEmpty() }
-    )
+    ) = dataSource.transaction {
+        SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(referanse)
+    }
 
     private fun hentSakstatistikkHendelserMedEksaktAntall(
         dataSource: DataSource,
         referanse: UUID
-    ) = ventPåSvar(
-        {
-            dataSource.transaction {
-                SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(referanse)
-            }
-        },
-        { t -> t !== null && t.isNotEmpty() }
-    )
+    ) = dataSource.transaction {
+        SakstatistikkRepositoryImpl(it).hentAlleHendelserPåBehandling(referanse)
+    }
 
 
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/api/MottaStatistikkTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/api/MottaStatistikkTest.kt
@@ -15,7 +15,7 @@ import no.nav.aap.behandlingsflyt.kontrakt.statistikk.*
 import no.nav.aap.komponenter.dbconnect.transaction
 import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.AzureConfig
 import no.nav.aap.komponenter.json.DefaultJsonMapper
-import no.nav.aap.motor.testutil.TestUtil
+import no.nav.aap.motor.testutil.ManuellMotorImpl
 import no.nav.aap.postmottak.kontrakt.hendelse.DokumentflytStoppetHendelse
 import no.nav.aap.postmottak.kontrakt.journalpost.JournalpostId
 import no.nav.aap.statistikk.*
@@ -30,7 +30,6 @@ import no.nav.aap.statistikk.jobber.appender.MotorJobbAppender
 import no.nav.aap.statistikk.oppgave.LagreOppgaveHendelseJobb
 import no.nav.aap.statistikk.oppgave.LagreOppgaveJobb
 import no.nav.aap.statistikk.postmottak.LagrePostmottakHendelseJobb
-import no.nav.aap.statistikk.postmottak.PostmottakBehandlingRepositoryImpl
 import no.nav.aap.statistikk.sak.SakRepositoryImpl
 import no.nav.aap.statistikk.sak.Saksnummer
 import no.nav.aap.statistikk.saksstatistikk.LagreSakinfoTilBigQueryJobb
@@ -176,7 +175,7 @@ class MottaStatistikkTest {
         val lagreAvklaringsbehovHendelseJobb =
             LagreAvklaringsbehovHendelseJobb(testJobber.motorJobbAppender)
 
-        val motor = konstruerMotor(
+        val motor = konstruerManuellMotor(
             dataSource,
             testJobber.motorJobbAppender,
             FakeBQYtelseRepository(),
@@ -196,7 +195,7 @@ class MottaStatistikkTest {
 
             oppdatertBehandlingHendelse(hendelse)
 
-            TestUtil(dataSource, listOf("oppgave.retryFeilede")).ventPåSvar()
+            motor.kjørJobber()
 
             val (behandling, bqBehandlinger) = dataSource.transaction {
                 val behandling = BehandlingRepository(it).hent(hendelse.behandlingReferanse)!!
@@ -248,7 +247,7 @@ class MottaStatistikkTest {
         val lagreAvklaringsbehovHendelseJobb =
             LagreAvklaringsbehovHendelseJobb(testJobber.motorJobbAppender)
 
-        val motor = konstruerMotor(
+        val motor = konstruerManuellMotor(
             dataSource,
             testJobber.motorJobbAppender,
             FakeBQYtelseRepository(),
@@ -257,7 +256,6 @@ class MottaStatistikkTest {
             lagrePostmottakHendelseJobb,
             testJobber.lagreSakinfoTilBigQueryJobb
         )
-        val testUtil = TestUtil(dataSource, listOf("oppgave.retryFeilede"))
 
         testKlient(
             transactionExecutor,
@@ -269,11 +267,11 @@ class MottaStatistikkTest {
 
             postBehandlingsflytHendelse(meldekorthendelse)
 
-            testUtil.ventPåSvar()
+            motor.kjørJobber()
 
             oppdatertBehandlingHendelse(meldekorthendelse)
 
-            testUtil.ventPåSvar()
+            motor.kjørJobber()
 
             val bqBehandlinger = dataSource.transaction {
                 val behandling =
@@ -311,7 +309,7 @@ class MottaStatistikkTest {
         val lagreAvklaringsbehovHendelseJobb =
             LagreAvklaringsbehovHendelseJobb(testJobber.motorJobbAppender)
 
-        val motor = konstruerMotor(
+        val motor = konstruerManuellMotor(
             dataSource,
             testJobber.motorJobbAppender,
             FakeBQYtelseRepository(),
@@ -331,13 +329,7 @@ class MottaStatistikkTest {
 
             postBehandlingsflytHendelse(hendelse)
 
-            dataSource.transaction(readOnly = true) {
-                ventPåSvar({
-                    SakRepositoryImpl(
-                        it
-                    ).tellSaker()
-                }, { it?.let { it > 0 } ?: false })
-            }
+            motor.kjørJobber()
         }
 
         val (uthentetSak, uthentetBehandling) = dataSource.transaction {
@@ -400,9 +392,8 @@ class MottaStatistikkTest {
         val resendSakstatistikkJobb = ResendSakstatistikkJobb()
         val jobbAppender = MotorJobbAppender()
         val lagreStoppetHendelseJobb = ekteLagreStoppetHendelseJobb(jobbAppender)
-        val motor = motor(
+        val motor = ManuellMotorImpl(
             dataSource = dataSource,
-            gatewayProvider = defaultGatewayProvider { },
             jobber = listOf(
                 resendSakstatistikkJobb,
                 lagreAvsluttetBehandlingTilBigQueryJobb,
@@ -412,7 +403,9 @@ class MottaStatistikkTest {
                 lagreOppgaveHendelseJobb,
                 lagreOppgaveJobb,
                 lagreStoppetHendelseJobb
-            )
+            ),
+            repositoryRegistry = postgresRepositoryRegistry,
+            gatewayProvider = defaultGatewayProvider { },
         )
 
         testKlient(
@@ -424,13 +417,7 @@ class MottaStatistikkTest {
         ) {
             postPostmottakHendelse(hendelse)
 
-            dataSource.transaction(readOnly = true) {
-                ventPåSvar({
-                    PostmottakBehandlingRepositoryImpl(
-                        it
-                    ).hentEksisterendeBehandling(referanse)
-                }, { it != null })
-            }
+            motor.kjørJobber()
         }
 
         dataSource.transaction {
@@ -473,7 +460,7 @@ class MottaStatistikkTest {
         val lagreStoppetHendelseJobb =
             LagreStoppetHendelseJobb(testJobber.motorJobbAppender, testJobber.lagreAvsluttetBehandlingTilBigQueryJobb)
 
-        val motor = konstruerMotor(
+        val motor = konstruerManuellMotor(
             dataSource,
             testJobber.motorJobbAppender,
             FakeBQYtelseRepository(),
@@ -482,8 +469,6 @@ class MottaStatistikkTest {
             lagrePostmottakHendelseJobb,
             testJobber.lagreSakinfoTilBigQueryJobb
         )
-
-        val testUtil = TestUtil(dataSource, listOf("oppgave.retryFeilede"))
 
         testKlient(
             transactionExecutor,
@@ -494,10 +479,10 @@ class MottaStatistikkTest {
         ) {
             // Opprett behandling først slik at tilbakekrevingshendelsen kan referere til den
             postBehandlingsflytHendelse(stoppetBehandling)
-            testUtil.ventPåSvar()
+            motor.kjørJobber()
 
             postTilbakekrevingshendelse(tilbakekrevingshendelse)
-            testUtil.ventPåSvar()
+            motor.kjørJobber()
         }
 
         val lagretHendelse = dataSource.transaction {

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -32,6 +32,7 @@ import no.nav.aap.komponenter.type.Periode
 import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.Motor
 import no.nav.aap.motor.retry.DriftJobbRepositoryExposed
+import no.nav.aap.motor.testutil.ManuellMotorImpl
 import no.nav.aap.motor.testutil.TestJobbRepository
 import no.nav.aap.oppgave.statistikk.OppgaveHendelse
 import no.nav.aap.postmottak.kontrakt.hendelse.DokumentflytStoppetHendelse
@@ -43,6 +44,7 @@ import no.nav.aap.statistikk.bigquery.*
 import no.nav.aap.statistikk.db.DbConfig
 import no.nav.aap.statistikk.db.TransactionExecutor
 import no.nav.aap.statistikk.defaultGatewayProvider
+import no.nav.aap.statistikk.postgresRepositoryRegistry
 import no.nav.aap.statistikk.hendelser.BehandlingService
 import no.nav.aap.statistikk.integrasjoner.pdl.Adressebeskyttelse
 import no.nav.aap.statistikk.integrasjoner.pdl.Gradering
@@ -208,6 +210,36 @@ fun konstruerMotor(
             LagreStoppetHendelseJobb(jobbAppender, lagreAvsluttetBehandlingTilBigQueryJobb),
             LagreTilbakekrevingHendelseJobb()
         )
+    )
+}
+
+fun konstruerManuellMotor(
+    dataSource: DataSource,
+    jobbAppender: MotorJobbAppender,
+    bqYtelseRepository: IBQYtelsesstatistikkRepository,
+    resendSakstatistikkJobb: ResendSakstatistikkJobb,
+    lagreAvklaringsbehovHendelseJobb: LagreAvklaringsbehovHendelseJobb,
+    lagrePostmottakHendelseJobb: LagrePostmottakHendelseJobb,
+    lagreSakinfoTilBigQueryJobb: LagreSakinfoTilBigQueryJobb
+): ManuellMotorImpl {
+    val lagreOppgaveJobb = LagreOppgaveJobb()
+    val lagreAvsluttetBehandlingTilBigQueryJobb =
+        LagreAvsluttetBehandlingTilBigQueryJobb(bqYtelseRepository)
+    return ManuellMotorImpl(
+        dataSource = dataSource,
+        jobber = listOf(
+            lagreAvsluttetBehandlingTilBigQueryJobb,
+            lagreOppgaveJobb,
+            resendSakstatistikkJobb,
+            lagreAvklaringsbehovHendelseJobb,
+            lagrePostmottakHendelseJobb,
+            LagreOppgaveHendelseJobb(),
+            lagreSakinfoTilBigQueryJobb,
+            LagreStoppetHendelseJobb(jobbAppender, lagreAvsluttetBehandlingTilBigQueryJobb),
+            LagreTilbakekrevingHendelseJobb()
+        ),
+        repositoryRegistry = postgresRepositoryRegistry,
+        gatewayProvider = defaultGatewayProvider { },
     )
 }
 

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -379,6 +379,56 @@ fun <E> testKlientNoInjection(
     return res
 }
 
+fun <E> testKlientNoInjectionManuell(
+    dbConfig: DbConfig,
+    azureConfig: AzureConfig = AzureConfig(
+        clientId = "tilgang",
+        jwksUri = "http://localhost:8081/jwks",
+        issuer = "tilgang"
+    ),
+    bigQueryClient: IBigQueryClient = FakeBigQueryClient,
+    test: TestClient.(ManuellMotorImpl) -> E,
+): E {
+    lateinit var motor: ManuellMotorImpl
+
+    System.setProperty("azure.openid.config.token.endpoint", azureConfig.tokenEndpoint.toString())
+    System.setProperty("azure.app.client.id", azureConfig.clientId)
+    System.setProperty("azure.app.client.secret", azureConfig.clientSecret)
+    System.setProperty("azure.openid.config.jwks.uri", azureConfig.jwksUri)
+    System.setProperty("azure.openid.config.issuer", azureConfig.issuer)
+
+    System.setProperty("NAIS_CLUSTER_NAME", "LOCAL")
+
+    System.setProperty("enhet.retry.max.retries", "1")
+    System.setProperty("enhet.retry.delay.seconds", "0")
+
+    val restClient = RestClient(
+        config = ClientConfig(scope = "AAP_SCOPES"),
+        tokenProvider = ClientCredentialsTokenProvider,
+        responseHandler = DefaultResponseHandler()
+    )
+
+    val server = embeddedServer(Netty, port = 0) {
+        startUp(
+            dbConfig,
+            azureConfig,
+            bigQueryClient,
+            defaultGatewayProvider()
+        ) { ds, gp, jobber ->
+            ManuellMotorImpl(ds, jobber, postgresRepositoryRegistry, gp).also { motor = it }
+        }
+    }.start()
+
+    val port = runBlocking { server.engine.resolvedConnectors().first().port }
+
+    val res = TestClient(restClient, "http://localhost:$port").test(motor)
+
+    server.stop(1000L, 10_000L)
+
+    return res
+}
+
+
 fun postgresTestConfig(): DbConfig {
     val postgres = PostgreSQLContainer("postgres:16")
     // Get the current working directory

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -136,6 +136,8 @@ fun <E> testKlient(
     )
     motor.start()
 
+    val lagreAvklaringsbehovHendelseJobb = LagreAvklaringsbehovHendelseJobb(jobbAppender)
+
     val server = embeddedServer(Netty, port = 0) {
         module(
             transactionExecutor,
@@ -143,6 +145,7 @@ fun <E> testKlient(
             azureConfig,
             {},
             lagreStoppetHendelseJobb,
+            lagreAvklaringsbehovHendelseJobb,
         )
     }.start()
 


### PR DESCRIPTION
## Hva er gjort

Erstatter `konstruerMotor()` + `TestUtil.ventPåSvar()` polling med `ManuellMotorImpl` + `motor.kjørJobber()` i `MottaStatistikkTest`.

Inspirert av tilsvarende oppsett i [aap-behandlingsflyt](https://github.com/navikt/aap-behandlingsflyt/blob/main/behandlingsflyt/src/test/kotlin/no/nav/aap/behandlingsflyt/flyt/AbstraktFlytOrkestratorTest.kt).

## Fordeler

- **Raskere tester**: `ManuellMotorImpl.kjørJobber()` prosesserer alle ventende jobber synkront, uten bakgrunnstråder og uten `Thread.sleep`-polling
- **Mer deterministiske tester**: Jobber kjøres ferdig før neste linje, ikke etter et tidsintervall

## Endringer

- **`TestUtils.kt`**: La til `konstruerManuellMotor()`-hjelper som returnerer `ManuellMotorImpl`
- **`MottaStatistikkTest.kt`**: Konverterte 5 tester fra polling til synkron jobbutføring