### PR TITLE
Fjern ubrukt kode

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/Extensions.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/Extensions.kt
@@ -6,5 +6,3 @@ import java.time.LocalDateTime
 fun LocalDateTime.isBeforeOrEqual(other: LocalDateTime): Boolean =
     this.isBefore(other) || this == other
 
-fun LocalDateTime.isAfterOrEqual(other: LocalDateTime): Boolean =
-    this.isAfter(other) || this == other

--- a/app/src/main/kotlin/no/nav/aap/statistikk/hendelser/hendelseHjelpere.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/hendelser/hendelseHjelpere.kt
@@ -9,11 +9,8 @@ import no.nav.aap.behandlingsflyt.kontrakt.steg.StegType
 import no.nav.aap.statistikk.behandling.BehandlingStatus
 import no.nav.aap.statistikk.isBeforeOrEqual
 import no.nav.aap.statistikk.onlyOrNull
-import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import no.nav.aap.behandlingsflyt.kontrakt.behandling.Status as KontraktBehandlingStatus
-
-private val log = LoggerFactory.getLogger("no.nav.aap.statistikk.hendelser.hendelseHjelpere")
 
 fun List<AvklaringsbehovHendelseDto>.utledVedtakTid(): LocalDateTime? {
     // Hvis FATTE_VEDTAK er løst, men det fortsatt finnes åpne behov, så betyr at det


### PR DESCRIPTION
Fjerner ubrukt kode funnet med detekt og manuell analyse:

- `isAfterOrEqual` i `Extensions.kt` — aldri brukt noe sted i kodebasen
- `private val log` og tilhørende import i `hendelseHjelpere.kt` — filen bruker bare top-level funksjoner, ingen logging