### PR TITLE
Forenkle bqBehandlingForBehandling til å returnere ett element

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
@@ -32,7 +32,7 @@ class BQBehandlingMapper(
     fun bqBehandlingForBehandling(
         behandling: Behandling,
         erSkjermet: Boolean,
-    ): List<BQBehandling> {
+    ): BQBehandling {
         val sak = behandling.sak
         val relatertBehandlingUUID =
             behandlingService.hentRelatertBehandlingUUID(behandling)
@@ -71,16 +71,14 @@ class BQBehandlingMapper(
             log.warn("Mottatt-tid er større enn opprettet-tid. Behandling: $behandlingReferanse. Mottatt: ${behandling.mottattTid}, opprettet: ${behandling.opprettetTid}.")
         }
 
-        return listOf(
-            byggBQBehandling(
-                behandling = behandling,
-                relatertBehandlingUUID = relatertBehandlingUUID,
-                erSkjermet = erSkjermet,
-                ansvarligEnhet = ansvarligEnhet,
-                saksbehandler = saksbehandler,
-                endretTid = snapshots.last().tidspunkt,
-                behandlingStatus = behandlingStatus(behandling)
-            )
+        return byggBQBehandling(
+            behandling = behandling,
+            relatertBehandlingUUID = relatertBehandlingUUID,
+            erSkjermet = erSkjermet,
+            ansvarligEnhet = ansvarligEnhet,
+            saksbehandler = saksbehandler,
+            endretTid = snapshots.last().tidspunkt,
+            behandlingStatus = behandlingStatus(behandling)
         )
     }
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
@@ -31,32 +31,29 @@ class SaksStatistikkService(
 
         val erSkjermet = behandlingService.erSkjermet(behandling)
 
-        val bqSaker =
+        val bqSak =
             bqBehandlingMapper.bqBehandlingForBehandling(behandling, erSkjermet)
 
-        bqSaker.forEach {
-            log.info(
-                "lagreSakInfoTilBigquery: endretTid=${it.endretTid}, " +
-                        "behandling.oppdatertTidspunkt=${behandling.oppdatertTidspunkt()}, " +
-                        "oppgaveDrivenEndretTid=${it.endretTid.isAfter(behandling.oppdatertTidspunkt())}, " +
-                        "status=${it.behandlingStatus}."
-            )
-        }
+        log.info(
+            "lagreSakInfoTilBigquery: endretTid=${bqSak.endretTid}, " +
+                    "behandling.oppdatertTidspunkt=${behandling.oppdatertTidspunkt()}, " +
+                    "oppgaveDrivenEndretTid=${bqSak.endretTid.isAfter(behandling.oppdatertTidspunkt())}, " +
+                    "status=${bqSak.behandlingStatus}."
+        )
 
-        val manglerEnhet = !lagreUtenEnhet && bqSaker.any {
-            it.ansvarligEnhetKode == null && it.behandlingMetode != BehandlingMetode.AUTOMATISK
-        }
+        val manglerEnhet = !lagreUtenEnhet &&
+                bqSak.ansvarligEnhetKode == null && bqSak.behandlingMetode != BehandlingMetode.AUTOMATISK
 
         if (manglerEnhet) {
             return SakStatistikkResultat.ManglerEnhet(
                 behandlingId = behandling.id(),
                 avklaringsbehovKode = behandling.gjeldendeAvklaringsBehov,
-                bqBehandling = bqSaker.single(),
+                bqBehandling = bqSak,
             )
         }
 
         val manglerFortsattEnhet =
-            bqSaker.any { it.ansvarligEnhetKode == null && it.behandlingMetode != BehandlingMetode.AUTOMATISK }
+            bqSak.ansvarligEnhetKode == null && bqSak.behandlingMetode != BehandlingMetode.AUTOMATISK
         if (manglerFortsattEnhet) {
             val referanse = behandling.referanse
             val saksnummer = behandling.sak.saksnummer
@@ -64,9 +61,7 @@ class SaksStatistikkService(
             log.warn("Saksbehandler er ikke satt. Behandling: $referanse. Sak: $saksnummer. Status: ${behandling.behandlingStatus()}. Årsak: ${behandling.årsakTilOpprettelse}.")
         }
 
-        bqSaker.forEach { bqSak ->
-            lagreBQBehandling(bqSak)
-        }
+        lagreBQBehandling(bqSak)
 
         return SakStatistikkResultat.OK
     }
@@ -178,7 +173,7 @@ class SaksStatistikkService(
             sakstatistikkRepository.hentAlleHendelserPåBehandling(behandling.referanse)
 
         val alleHendelser = behandling.hendelsesHistorikk()
-            .flatMap { behandling ->
+            .map { behandling ->
                 bqBehandlingMapper.bqBehandlingForBehandling(
                     behandling = behandling,
                     erSkjermet = erSkjermet,

--- a/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapperTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapperTest.kt
@@ -146,7 +146,7 @@ class BQBehandlingMapperTest {
         )
 
         val result =
-            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false).last()
+            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false)
 
         assertThat(result.saksbehandler)
             .describedAs("Saksbehandler should be null when no oppgave is reserved yet")
@@ -236,7 +236,7 @@ class BQBehandlingMapperTest {
         )
 
         val result =
-            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false).last()
+            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false)
 
         assertThat(result.saksbehandler).isEqualTo("Kvaliguy")
         assertThat(result.ansvarligEnhetKode).isEqualTo("0400")
@@ -296,7 +296,7 @@ class BQBehandlingMapperTest {
         )
 
         val result =
-            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false).last()
+            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false)
 
         assertThat(result.saksbehandler)
             .describedAs("Should not use saksbehandler from previous avklaringsbehov")
@@ -340,7 +340,7 @@ class BQBehandlingMapperTest {
 
         // Execute
         val result =
-            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false).last()
+            mapper.bqBehandlingForBehandling(behandling, erSkjermet = false)
 
         // Assert: Saksbehandler skal være null når det ikke finnes oppgave-data
         assertThat(result.saksbehandler)


### PR DESCRIPTION
Metoden returnerte alltid en liste med nøyaktig ett element. Returnerer nå `BQBehandling` direkte istedenfor `List<BQBehandling>`.

Kalles på to steder i `SaksStatistikkService` – begge er oppdatert.