### PR TITLE
docs: legg til prettier-regel for markdown-filer i AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Known terms: "bug" (not "bugg").
 - Delete temporary files when done
 
 ### Small, Incremental Changes
+
 - **Always make the smallest possible change** that moves toward the goal
 - Add new methods/functions rather than modifying existing ones when possible
 - Keep existing functionality working while adding new features
@@ -30,36 +31,48 @@ Known terms: "bug" (not "bugg").
 - Verify each change compiles and tests pass before moving to next change
 
 ### Documentation
+
 - Don't add docstrings to methods and classes unless they are very complicated
 - Prefer clear method names over documentation
 - Add comments only when the code needs clarification
+- **Always run `npx prettier --write <file>` on markdown files after creating or editing them**
 
 ### Immutable State
+
 We prefer immutable state throughout the codebase. Avoid mutating objects and collections; instead, create new instances with the desired changes.
 
 ### Test-Driven Development
+
 Always write tests before making functional changes. Tests should be written first to:
+
 - Define expected behavior
 - Drive the design of the implementation
 - Ensure the changes work as intended
 
 ### Testing Strategy
+
 For testing, prefer in-memory fakes over mocks. Fakes provide:
+
 - More realistic behavior
 - Better refactoring support
 - Clearer test intentions
 - Reduced coupling to implementation details
 
 ### Gradle Commands
+
 - **Never use --no-daemon** when running Gradle tests or builds - it's slower
 - The Gradle daemon improves build performance through caching and hot JVM
 - **Run `./gradlew detektMain` after significant code changes** to check code quality
 - Fix any Detekt violations before committing
 
 ### Domain Classes vs. Kontrakt
+
 Never use kontrakt (e.g. `behandlingsflyt.kontrakt`) types directly in domain logic, repositories, or database storage. Always map to local domain classes first. This keeps the domain decoupled from external contracts.
+
 ### BQBehandling Duplication Logic
+
 **Important**: BQBehandling events are NOT saved if they are duplicates of the last event.
+
 - Duplication check is in `BQBehandling.ansesSomDuplikat()` (BQSak.kt line 69)
 - It compares all fields EXCEPT: `sekvensNummer`, `erResending`, `tekniskTid`, `endretTid`, `versjon`
 - If two consecutive events differ ONLY in these ignored fields, the second one is NOT saved


### PR DESCRIPTION
Legger til regel om å kjøre `npx prettier --write <file>` på markdown-filer etter opprettelse eller redigering.