### PR TITLE
fix: lagre forsinket hendelse med opprinnelig endretTid istedenfor bump

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
@@ -156,7 +156,7 @@ class SaksStatistikkService(
         }
         siste.endretTid > bqSak.endretTid -> {
             val eksisterende = sakstatistikkRepository.hentHendelseMedEndretTid(
-                bqSak.behandlingUUID, bqSak.endretTid
+                bqSak.behandlingUUID, bqSak.endretTid, bqSak.erResending
             )
             if (eksisterende?.ansesSomDuplikat(bqSak) == true) {
                 log.info(

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
@@ -113,38 +113,35 @@ class SaksStatistikkService(
                 PrometheusProvider.prometheus.sakDuplikat(false).increment()
             }
 
-            // Sikrer monoton rekkefølge: ny rad må alltid ha høyere endretTid enn forrige rad.
+            // Sikrer unik endretTid: to samtidige hendelser kan beregne nøyaktig samme tidsstempel.
             // Kan skje at oppgave-trigget og behandling-trigget jobb beregner samme
             // endretTid dersom oppgavens sendtTid er nyere enn behandlingens hendelsesTidspunkt
             // (oppgave er da siste snapshot for begge jobber), men jobbene ser ulike behandlingstilstander.
-            val bqSakMedUnikEndretTid = if (siste != null && siste.endretTid >= bqSak.endretTid) {
+            //
+            // Dersom ny hendelse har eldre endretTid enn forrige lagrede rad (forsinket retry-jobb),
+            // lagres den med sin opprinnelige endretTid. Den havner da på riktig historisk posisjon,
+            // og gjeldende tilstand (høyeste endretTid i BigQuery) forblir korrekt.
+            val bqSakMedUnikEndretTid = if (siste != null && siste.endretTid == bqSak.endretTid) {
                 val justert = bqSak.copy(endretTid = siste.endretTid.plusNanos(1000))
-                if (siste.endretTid == bqSak.endretTid) {
-                    log.info(
-                        "Ny hendelse med samme endretTid. Forrige teknisk tid: ${siste.tekniskTid}. " +
-                                "Ny: ${bqSak.tekniskTid}. Referanse: ${bqSak.behandlingUUID}. " +
-                                "EndretTid: ${bqSak.endretTid}. " +
-                                "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}. " +
-                                "Forrige saksbehandler: ${siste.saksbehandler}, ny: ${bqSak.saksbehandler}. " +
-                                "Forrige enhet: ${siste.ansvarligEnhetKode}, ny: ${bqSak.ansvarligEnhetKode}."
-                    )
-                } else {
-                    log.warn(
-                        "Ny hendelse har eldre endretTid enn forrige lagrede rad. Referanse: ${bqSak.behandlingUUID}. " +
-                                "Forrige endretTid: ${siste.endretTid}, ny: ${bqSak.endretTid}. " +
-                                "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}."
-                    )
-                }
-                val diffNanos = java.time.Duration.between(bqSak.endretTid, justert.endretTid).toNanos()
                 log.info(
-                    "Justerte endretTid fra ${bqSak.endretTid} til ${justert.endretTid} " +
-                            "(diff: ${diffNanos}ns) " +
-                            "for å sikre monoton rekkefølge. Referanse: ${bqSak.behandlingUUID}. " +
-                            "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}."
+                    "Ny hendelse med samme endretTid. Forrige teknisk tid: ${siste.tekniskTid}. " +
+                            "Ny: ${bqSak.tekniskTid}. Referanse: ${bqSak.behandlingUUID}. " +
+                            "EndretTid: ${bqSak.endretTid}. " +
+                            "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}. " +
+                            "Forrige saksbehandler: ${siste.saksbehandler}, ny: ${bqSak.saksbehandler}. " +
+                            "Forrige enhet: ${siste.ansvarligEnhetKode}, ny: ${bqSak.ansvarligEnhetKode}."
                 )
                 PrometheusProvider.prometheus.sammeEndretTid().increment()
                 justert
             } else {
+                if (siste != null && siste.endretTid > bqSak.endretTid) {
+                    log.warn(
+                        "Ny hendelse har eldre endretTid enn forrige lagrede rad — lagrer med opprinnelig tidsstempel. " +
+                                "Referanse: ${bqSak.behandlingUUID}. " +
+                                "Forrige endretTid: ${siste.endretTid}, ny: ${bqSak.endretTid}. " +
+                                "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}."
+                    )
+                }
                 bqSak
             }
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkService.kt
@@ -113,36 +113,9 @@ class SaksStatistikkService(
                 PrometheusProvider.prometheus.sakDuplikat(false).increment()
             }
 
-            // Sikrer unik endretTid: to samtidige hendelser kan beregne nøyaktig samme tidsstempel.
-            // Kan skje at oppgave-trigget og behandling-trigget jobb beregner samme
-            // endretTid dersom oppgavens sendtTid er nyere enn behandlingens hendelsesTidspunkt
-            // (oppgave er da siste snapshot for begge jobber), men jobbene ser ulike behandlingstilstander.
-            //
-            // Dersom ny hendelse har eldre endretTid enn forrige lagrede rad (forsinket retry-jobb),
-            // lagres den med sin opprinnelige endretTid. Den havner da på riktig historisk posisjon,
-            // og gjeldende tilstand (høyeste endretTid i BigQuery) forblir korrekt.
-            val bqSakMedUnikEndretTid = if (siste != null && siste.endretTid == bqSak.endretTid) {
-                val justert = bqSak.copy(endretTid = siste.endretTid.plusNanos(1000))
-                log.info(
-                    "Ny hendelse med samme endretTid. Forrige teknisk tid: ${siste.tekniskTid}. " +
-                            "Ny: ${bqSak.tekniskTid}. Referanse: ${bqSak.behandlingUUID}. " +
-                            "EndretTid: ${bqSak.endretTid}. " +
-                            "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}. " +
-                            "Forrige saksbehandler: ${siste.saksbehandler}, ny: ${bqSak.saksbehandler}. " +
-                            "Forrige enhet: ${siste.ansvarligEnhetKode}, ny: ${bqSak.ansvarligEnhetKode}."
-                )
-                PrometheusProvider.prometheus.sammeEndretTid().increment()
-                justert
-            } else {
-                if (siste != null && siste.endretTid > bqSak.endretTid) {
-                    log.warn(
-                        "Ny hendelse har eldre endretTid enn forrige lagrede rad — lagrer med opprinnelig tidsstempel. " +
-                                "Referanse: ${bqSak.behandlingUUID}. " +
-                                "Forrige endretTid: ${siste.endretTid}, ny: ${bqSak.endretTid}. " +
-                                "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}."
-                    )
-                }
-                bqSak
+            val bqSakMedUnikEndretTid = tilpassEndretTid(bqSak, siste) ?: run {
+                PrometheusProvider.prometheus.sakDuplikat(true).increment()
+                return
             }
 
             sakstatistikkRepository.lagre(bqSakMedUnikEndretTid)
@@ -158,6 +131,50 @@ class SaksStatistikkService(
             log.info("Lagret ikke sakstatistikk for behandling ${bqSak.behandlingUUID} siden den anses som duplikat.")
             PrometheusProvider.prometheus.sakDuplikat(true).increment()
         }
+    }
+
+    /**
+     * Justerer endretTid for å sikre korrekt rekkefølge og idempotens:
+     * - Samme endretTid som siste: bumpes med +1µs (to samtidige hendelser)
+     * - Eldre endretTid enn siste: lagres med opprinnelig tidsstempel på riktig historisk posisjon;
+     *   returnerer null dersom hendelsen allerede er lagret (idempotens ved gjentagende retries)
+     * - Nyere endretTid enn siste: returneres uendret
+     */
+    private fun tilpassEndretTid(bqSak: BQBehandling, siste: BQBehandling?): BQBehandling? = when {
+        siste == null -> bqSak
+        siste.endretTid == bqSak.endretTid -> {
+            log.info(
+                "Ny hendelse med samme endretTid. Forrige teknisk tid: ${siste.tekniskTid}. " +
+                        "Ny: ${bqSak.tekniskTid}. Referanse: ${bqSak.behandlingUUID}. " +
+                        "EndretTid: ${bqSak.endretTid}. " +
+                        "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}. " +
+                        "Forrige saksbehandler: ${siste.saksbehandler}, ny: ${bqSak.saksbehandler}. " +
+                        "Forrige enhet: ${siste.ansvarligEnhetKode}, ny: ${bqSak.ansvarligEnhetKode}."
+            )
+            PrometheusProvider.prometheus.sammeEndretTid().increment()
+            bqSak.copy(endretTid = siste.endretTid.plusNanos(1000))
+        }
+        siste.endretTid > bqSak.endretTid -> {
+            val eksisterende = sakstatistikkRepository.hentHendelseMedEndretTid(
+                bqSak.behandlingUUID, bqSak.endretTid
+            )
+            if (eksisterende?.ansesSomDuplikat(bqSak) == true) {
+                log.info(
+                    "Forsinket hendelse allerede lagret med samme endretTid — hopper over. " +
+                            "Referanse: ${bqSak.behandlingUUID}. endretTid: ${bqSak.endretTid}."
+                )
+                null
+            } else {
+                log.warn(
+                    "Ny hendelse har eldre endretTid enn forrige lagrede rad — lagrer med opprinnelig tidsstempel. " +
+                            "Referanse: ${bqSak.behandlingUUID}. " +
+                            "Forrige endretTid: ${siste.endretTid}, ny: ${bqSak.endretTid}. " +
+                            "Forrige status: ${siste.behandlingStatus}, ny status: ${bqSak.behandlingStatus}."
+                )
+                bqSak
+            }
+        }
+        else -> bqSak
     }
 
     private fun erInngangsHendelse(bqBehandling: BQBehandling): Boolean {

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepository.kt
@@ -10,7 +10,7 @@ interface SakstatistikkRepository : Repository {
 
     fun hentSisteHendelseForBehandling(uuid: UUID): BQBehandling?
 
-    fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime): BQBehandling?
+    fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime, erResending: Boolean): BQBehandling?
 
     fun hentAlleHendelserPåBehandling(referanse: UUID): List<BQBehandling>
 }

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.aap.statistikk.saksstatistikk
 
 import no.nav.aap.komponenter.repository.Repository
+import java.time.LocalDateTime
 import java.util.*
 
 interface SakstatistikkRepository : Repository {
@@ -8,6 +9,8 @@ interface SakstatistikkRepository : Repository {
     fun lagreFlere(bqBehandlinger: List<BQBehandling>)
 
     fun hentSisteHendelseForBehandling(uuid: UUID): BQBehandling?
+
+    fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime): BQBehandling?
 
     fun hentAlleHendelserPåBehandling(referanse: UUID): List<BQBehandling>
 }

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
@@ -114,15 +114,16 @@ class SakstatistikkRepositoryImpl(private val dbConnection: DBConnection) :
         }
     }
 
-    override fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime): BQBehandling? {
+    override fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime, erResending: Boolean): BQBehandling? {
         val sql = """
-            select * from saksstatistikk where behandling_uuid = ? and endret_tid = ? limit 1
+            select * from saksstatistikk where behandling_uuid = ? and endret_tid = ? and er_relast = ? limit 1
         """.trimIndent()
 
         return dbConnection.queryFirstOrNull(sql) {
             setParams {
                 setUUID(1, uuid)
                 setLocalDateTime(2, endretTid)
+                setBoolean(3, erResending)
             }
             setRowMapper {
                 rowMapper(it)

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
@@ -116,7 +116,7 @@ class SakstatistikkRepositoryImpl(private val dbConnection: DBConnection) :
 
     override fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime, erResending: Boolean): BQBehandling? {
         val sql = """
-            select * from saksstatistikk where behandling_uuid = ? and endret_tid = ? and er_relast = ? limit 1
+            select * from saksstatistikk where behandling_uuid = ? and endret_tid = ? and er_relast = ? order by teknisk_tid desc limit 1
         """.trimIndent()
 
         return dbConnection.queryFirstOrNull(sql) {

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkRepositoryImpl.kt
@@ -6,6 +6,7 @@ import no.nav.aap.komponenter.dbconnect.Row
 import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.behandling.SøknadsFormat
 import org.slf4j.LoggerFactory
+import java.time.LocalDateTime
 import java.util.*
 
 class SakstatistikkRepositoryImpl(private val dbConnection: DBConnection) :
@@ -106,6 +107,22 @@ class SakstatistikkRepositoryImpl(private val dbConnection: DBConnection) :
         return dbConnection.queryFirstOrNull(sql) {
             setParams {
                 setUUID(1, uuid)
+            }
+            setRowMapper {
+                rowMapper(it)
+            }
+        }
+    }
+
+    override fun hentHendelseMedEndretTid(uuid: UUID, endretTid: LocalDateTime): BQBehandling? {
+        val sql = """
+            select * from saksstatistikk where behandling_uuid = ? and endret_tid = ? limit 1
+        """.trimIndent()
+
+        return dbConnection.queryFirstOrNull(sql) {
+            setParams {
+                setUUID(1, uuid)
+                setLocalDateTime(2, endretTid)
             }
             setRowMapper {
                 rowMapper(it)

--- a/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceTest.kt
@@ -327,6 +327,53 @@ class SaksStatistikkServiceTest {
     }
 
     @Test
+    fun `lagreBQBehandling er idempotent for forsinket hendelse som kjøres to ganger`(
+        @Postgres dataSource: DataSource
+    ) {
+        val behandlingUUID = UUID.randomUUID()
+        val t2 = LocalDateTime.of(2024, 1, 1, 10, 0, 10)
+        val t0 = t2.minusSeconds(8)  // stale: eldre enn t2
+
+        dataSource.transaction { conn ->
+            val service = konstruerSakstatistikkService(conn)
+            val repo = SakstatistikkRepositoryImpl(conn)
+
+            // T2: første hendelse (inngangshendelse — registrertTid == endretTid → ingen ekstra OPPRETTET-rad)
+            val nyesteHendelse = lagTestBQBehandling(
+                behandlingUUID = behandlingUUID,
+                endretTid = t2,
+                registrertTid = t2,
+                behandlingStatus = "UNDER_BEHANDLING",
+            )
+            service.lagreBQBehandling(nyesteHendelse)
+
+            // T0: forsinket retry-jobb med eldre endretTid og ulik status
+            val forsinketHendelse = lagTestBQBehandling(
+                behandlingUUID = behandlingUUID,
+                endretTid = t0,
+                registrertTid = t2,
+                behandlingStatus = "AVSLUTTET",
+            )
+            service.lagreBQBehandling(forsinketHendelse)  // første gang: lagres
+
+            val antallEtterFørsteRetry = repo.hentAlleHendelserPåBehandling(behandlingUUID).size
+
+            service.lagreBQBehandling(forsinketHendelse)  // andre gang: skal hoppes over
+
+            val alleRader = repo.hentAlleHendelserPåBehandling(behandlingUUID)
+            assertThat(alleRader)
+                .describedAs("Gjentagende retry skal ikke lagre dobbel rad")
+                .hasSize(antallEtterFørsteRetry)
+            assertThat(alleRader.any { it.endretTid == t0 && it.behandlingStatus == "AVSLUTTET" })
+                .describedAs("Forsinket hendelse skal ha blitt lagret med opprinnelig endretTid")
+                .isTrue()
+            assertThat(alleRader.maxBy { it.endretTid }.endretTid)
+                .describedAs("Gjeldende tilstand skal fortsatt være t2")
+                .isEqualTo(t2)
+        }
+    }
+
+    @Test
     fun `retry etter ManglerEnhet ser allerede lagret rad som duplikat og lagrer ikke på nytt`(
         @Postgres dataSource: DataSource
     ) {
@@ -568,5 +615,33 @@ class SaksStatistikkServiceTest {
 
             return behandlingReferanse
         }
+
+        fun lagTestBQBehandling(
+            behandlingUUID: UUID = UUID.randomUUID(),
+            endretTid: LocalDateTime = LocalDateTime.now(),
+            registrertTid: LocalDateTime = endretTid,
+            behandlingStatus: String = "UNDER_BEHANDLING",
+        ) = BQBehandling(
+            behandlingUUID = behandlingUUID,
+            behandlingType = "FØRSTEGANGSBEHANDLING",
+            aktorId = "12345678901",
+            saksnummer = "TESTSAKSNR",
+            tekniskTid = LocalDateTime.now(),
+            registrertTid = registrertTid,
+            endretTid = endretTid,
+            versjon = "v1",
+            mottattTid = registrertTid,
+            opprettetAv = "Kelvin",
+            ansvarligBeslutter = null,
+            søknadsFormat = SøknadsFormat.DIGITAL,
+            saksbehandler = null,
+            behandlingMetode = BehandlingMetode.MANUELL,
+            behandlingStatus = behandlingStatus,
+            behandlingÅrsak = "SØKNAD",
+            resultatBegrunnelse = null,
+            ansvarligEnhetKode = "4491",
+            sakYtelse = "AAP",
+            erResending = false,
+        )
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceTest.kt
@@ -204,6 +204,129 @@ class SaksStatistikkServiceTest {
     }
 
     @Test
+    fun `lagreBQBehandling skal lagre hendelse med eldre endretTid på riktig historisk posisjon`(
+        @Postgres dataSource: DataSource
+    ) {
+        val behandlingReferanse = UUID.randomUUID()
+        val behandlingsflytTid = LocalDateTime.of(2024, 1, 1, 10, 0, 0)
+        val oppgaveSendtTid = behandlingsflytTid.plusSeconds(5)
+
+        dataSource.transaction { conn ->
+            val hendelsesService = HendelsesService(
+                sakService = SakService(SakRepositoryImpl(conn)),
+                avsluttetBehandlingService = mockk(relaxed = true),
+                personService = PersonService(PersonRepository(conn)),
+                meldekortRepository = MeldekortRepository(conn),
+                opprettBigQueryLagringSakStatistikkCallback = { _ -> },
+                behandlingService = BehandlingService(
+                    BehandlingRepository(conn),
+                    SkjermingService(FakePdlGateway(emptyMap()))
+                ),
+            )
+
+            hendelsesService.prosesserNyHendelse(
+                StoppetBehandling(
+                    saksnummer = "EEEE",
+                    sakStatus = SakStatus.UTREDES,
+                    behandlingReferanse = behandlingReferanse,
+                    relatertBehandling = null,
+                    behandlingOpprettetTidspunkt = behandlingsflytTid,
+                    mottattTid = behandlingsflytTid,
+                    behandlingStatus = BehandlingStatus.UTREDES,
+                    behandlingType = TypeBehandling.Førstegangsbehandling,
+                    soknadsFormat = Kanal.DIGITAL,
+                    ident = "1234567893",
+                    versjon = "1",
+                    vurderingsbehov = listOf(Vurderingsbehov.VURDER_RETTIGHETSPERIODE),
+                    årsakTilOpprettelse = ÅrsakTilOpprettelse.SØKNAD,
+                    avklaringsbehov = listOf(
+                        AvklaringsbehovHendelseDto(
+                            avklaringsbehovDefinisjon = Definisjon.VURDER_RETTIGHETSPERIODE,
+                            status = AvklaringsbehovStatus.OPPRETTET,
+                            endringer = listOf(
+                                EndringDTO(
+                                    status = AvklaringsbehovStatus.OPPRETTET,
+                                    tidsstempel = behandlingsflytTid,
+                                    endretAv = "system",
+                                )
+                            ),
+                        )
+                    ),
+                    hendelsesTidspunkt = behandlingsflytTid,
+                    avsluttetBehandling = null,
+                    identerForSak = listOf("1234567893")
+                )
+            )
+
+            val enhetId = EnhetRepositoryImpl(conn).lagreEnhet(Enhet(null, "4491"))
+            OppgaveRepositoryImpl(conn).lagreOppgave(
+                Oppgave(
+                    identifikator = 88L,
+                    avklaringsbehov = Definisjon.VURDER_RETTIGHETSPERIODE.kode.name,
+                    enhet = Enhet(enhetId, "4491"),
+                    person = PersonRepository(conn).hentPerson("1234567893")!!,
+                    status = Oppgavestatus.OPPRETTET,
+                    opprettetTidspunkt = oppgaveSendtTid,
+                    behandlingReferanse = BehandlingReferanse(referanse = behandlingReferanse),
+                    hendelser = emptyList(),
+                )
+            )
+            OppgaveHendelseRepositoryImpl(conn).lagreHendelse(
+                OppgaveHendelse(
+                    hendelse = HendelseType.OPPRETTET,
+                    oppgaveId = 88L,
+                    mottattTidspunkt = oppgaveSendtTid,
+                    personIdent = "1234567893",
+                    saksnummer = "EEEE",
+                    behandlingRef = behandlingReferanse,
+                    enhet = "4491",
+                    avklaringsbehovKode = Definisjon.VURDER_RETTIGHETSPERIODE.kode.name,
+                    status = Oppgavestatus.OPPRETTET,
+                    reservertAv = null,
+                    reservertTidspunkt = null,
+                    opprettetTidspunkt = oppgaveSendtTid,
+                    endretAv = null,
+                    endretTidspunkt = null,
+                    sendtTid = oppgaveSendtTid,
+                    versjon = 1L,
+                )
+            )
+
+            val behandlingId = BehandlingRepository(conn).hent(behandlingReferanse)!!.id()
+            val service = konstruerSakstatistikkService(conn)
+
+            // Lagre hendelser for behandlingen (OPPRETTET + UNDER_BEHANDLING med endretTid = oppgaveSendtTid)
+            service.lagreSakInfoTilBigquery(behandlingId)
+
+            // Hent siste rad — dette er den "nyere" hendelsen vi vil bevare som gjeldende tilstand
+            val nyesteRad = SakstatistikkRepositoryImpl(conn)
+                .hentAlleHendelserPåBehandling(behandlingReferanse).last()
+
+            // Simuler forsinket retry-jobb: hendelse med eldre endretTid (mellom OPPRETTET og UNDER_BEHANDLING)
+            // og annen enhet (ikke duplikat av eksisterende rader).
+            val stalTidspunkt = behandlingsflytTid.plusSeconds(2)
+            val forsinketHendelse = nyesteRad.copy(
+                ansvarligEnhetKode = "ANNEN_ENHET",
+                endretTid = stalTidspunkt
+            )
+            service.lagreBQBehandling(forsinketHendelse)
+
+            val alleRaderSortert = SakstatistikkRepositoryImpl(conn)
+                .hentAlleHendelserPåBehandling(behandlingReferanse)
+                .sortedBy { it.endretTid }
+
+            // Forsinket hendelse skal lagres med sin opprinnelige endretTid
+            assertThat(alleRaderSortert.any { it.endretTid == stalTidspunkt && it.ansvarligEnhetKode == "ANNEN_ENHET" })
+                .describedAs("Forsinket hendelse skal være lagret med opprinnelig endretTid")
+                .isTrue()
+            // Gjeldende tilstand (høyeste endretTid) skal fortsatt være den nyeste hendelsen
+            assertThat(alleRaderSortert.last().endretTid)
+                .describedAs("Nyeste rad skal fortsatt ha oppgaveSendtTid som endretTid")
+                .isEqualTo(oppgaveSendtTid)
+        }
+    }
+
+    @Test
     fun `retry etter ManglerEnhet ser allerede lagret rad som duplikat og lagrer ikke på nytt`(
         @Postgres dataSource: DataSource
     ) {


### PR DESCRIPTION
## Problem

Hendelser med eldre `endretTid` enn siste lagrede rad ble bumped (+1µs etter forrige rad). Dette plasserte den utdaterte hendelsen som nyeste tilstand i BigQuery og ga feil gjeldende status.

Eksempel fra produksjon (behandling `44f0684d`):
- MANUELL (T136745) → MANUELL (ingen saksbehandler, retry-jobb forsinket) → KVALITETSSIKRING
- Retry-jobben ble bumped til å se nyere ut enn KVALITETSSIKRING → MANUELL vistes som gjeldende status

## Løsning

Splitter de to tilfellene som tidligere ble håndtert likt:

| Situasjon | Tidligere | Nå |
|---|---|---|
| Samme `endretTid` (`==`) | Bump +1µs | Bump +1µs (uendret) |
| Eldre `endretTid` (`>`) | Bump +1µs etter forrige | Lagre med opprinnelig tidsstempel |

Ved å lagre med opprinnelig `endretTid` havner hendelsen på riktig historisk posisjon, og gjeldende tilstand (høyeste `endretTid` i BigQuery) forblir korrekt. Ingen statuser (f.eks. AVSLUTTET, IVERKSETTES) går tapt.