### PR TITLE
Legg til hent() i VedtattStansOpphørRepository

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepository.kt
@@ -5,4 +5,5 @@ import no.nav.aap.statistikk.behandling.BehandlingId
 
 interface VedtattStansOpphørRepository : Repository {
     fun lagre(behandlingId: BehandlingId, vedtattStansOpphør: List<StansEllerOpphør>)
+    fun hent(behandlingId: BehandlingId): List<StansEllerOpphør>
 }

--- a/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepositoryImpl.kt
@@ -3,6 +3,7 @@ package no.nav.aap.statistikk.avsluttetbehandling
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.behandling.BehandlingId
+import java.time.LocalDate
 
 class VedtattStansOpphørRepositoryImpl(private val dbConnection: DBConnection) :
     VedtattStansOpphørRepository {
@@ -59,5 +60,40 @@ class VedtattStansOpphørRepositoryImpl(private val dbConnection: DBConnection) 
                 }
             }
         }
+    }
+
+    override fun hent(behandlingId: BehandlingId): List<StansEllerOpphør> {
+        data class Rad(val id: Long, val type: String, val fom: LocalDate, val aarsak: String?)
+
+        val rader = dbConnection.queryList(
+            """
+            SELECT s.id, s.type, s.fom, a.aarsak
+            FROM vedtatt_stans_opphor s
+            LEFT JOIN vedtatt_stans_opphor_aarsak a ON a.vedtatt_stans_opphor_id = s.id
+            WHERE s.behandling_id = ?
+            ORDER BY s.id
+            """.trimIndent()
+        ) {
+            setParams { setLong(1, behandlingId.id) }
+            setRowMapper {
+                Rad(
+                    id = it.getLong("id"),
+                    type = it.getString("type"),
+                    fom = it.getLocalDate("fom"),
+                    aarsak = it.getString("aarsak")
+                )
+            }
+        }
+
+        return rader
+            .groupBy { it.id }
+            .map { (_, raderForStans) ->
+                val første = raderForStans.first()
+                StansEllerOpphør(
+                    type = StansType.valueOf(første.type),
+                    fom = første.fom,
+                    årsaker = raderForStans.mapNotNull { it.aarsak }.map { Avslagsårsak.valueOf(it) }.toSet()
+                )
+            }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepositoryImplTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/VedtattStansOpphørRepositoryImplTest.kt
@@ -11,9 +11,8 @@ import javax.sql.DataSource
 
 class VedtattStansOpphørRepositoryImplTest {
     @Test
-    fun `lagre to perioder og verifiser i databasen`(@Postgres dataSource: DataSource) {
-        val behandlingReferanse = UUID.randomUUID()
-        val behandlingId = dataSource.transaction { forberedDatabase(it, behandlingReferanse) }
+    fun `lagre og hent igjen`(@Postgres dataSource: DataSource) {
+        val behandlingId = dataSource.transaction { forberedDatabase(it, UUID.randomUUID()) }
 
         val stansOpphørListe = listOf(
             StansEllerOpphør(
@@ -31,37 +30,16 @@ class VedtattStansOpphørRepositoryImplTest {
             )
         )
 
-        dataSource.transaction {
-            VedtattStansOpphørRepositoryImpl(it).lagre(behandlingId, stansOpphørListe)
-        }
+        dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).lagre(behandlingId, stansOpphørListe) }
 
-        val antallPerioder = dataSource.transaction { conn ->
-            conn.queryFirst("SELECT COUNT(*) AS count FROM vedtatt_stans_opphor WHERE behandling_id = ?") {
-                setParams { setLong(1, behandlingId.id) }
-                setRowMapper { it.getInt("count") }
-            }
-        }
-        assertThat(antallPerioder).isEqualTo(2)
+        val resultat = dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).hent(behandlingId) }
 
-        val antallÅrsaker = dataSource.transaction { conn ->
-            conn.queryFirst(
-                """
-                SELECT COUNT(*) AS count FROM vedtatt_stans_opphor_aarsak a
-                JOIN vedtatt_stans_opphor s ON a.vedtatt_stans_opphor_id = s.id
-                WHERE s.behandling_id = ?
-                """.trimIndent()
-            ) {
-                setParams { setLong(1, behandlingId.id) }
-                setRowMapper { it.getInt("count") }
-            }
-        }
-        assertThat(antallÅrsaker).isEqualTo(3)
+        assertThat(resultat).usingRecursiveComparison().isEqualTo(stansOpphørListe)
     }
 
     @Test
     fun `tom liste sletter eksisterende data`(@Postgres dataSource: DataSource) {
-        val behandlingReferanse = UUID.randomUUID()
-        val behandlingId = dataSource.transaction { forberedDatabase(it, behandlingReferanse) }
+        val behandlingId = dataSource.transaction { forberedDatabase(it, UUID.randomUUID()) }
 
         dataSource.transaction {
             VedtattStansOpphørRepositoryImpl(it).lagre(
@@ -69,23 +47,16 @@ class VedtattStansOpphørRepositoryImplTest {
                 listOf(StansEllerOpphør(StansType.STANS, LocalDate.of(2024, 1, 1), setOf(Avslagsårsak.BRUDD_PÅ_AKTIVITETSPLIKT_STANS)))
             )
         }
-        dataSource.transaction {
-            VedtattStansOpphørRepositoryImpl(it).lagre(behandlingId, emptyList())
-        }
+        dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).lagre(behandlingId, emptyList()) }
 
-        val antall = dataSource.transaction { conn ->
-            conn.queryFirst("SELECT COUNT(*) AS count FROM vedtatt_stans_opphor WHERE behandling_id = ?") {
-                setParams { setLong(1, behandlingId.id) }
-                setRowMapper { it.getInt("count") }
-            }
-        }
-        assertThat(antall).isEqualTo(0)
+        val resultat = dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).hent(behandlingId) }
+
+        assertThat(resultat).isEmpty()
     }
 
     @Test
     fun `overskriv eksisterende data ved ny lagring`(@Postgres dataSource: DataSource) {
-        val behandlingReferanse = UUID.randomUUID()
-        val behandlingId = dataSource.transaction { forberedDatabase(it, behandlingReferanse) }
+        val behandlingId = dataSource.transaction { forberedDatabase(it, UUID.randomUUID()) }
 
         dataSource.transaction {
             VedtattStansOpphørRepositoryImpl(it).lagre(
@@ -93,19 +64,14 @@ class VedtattStansOpphørRepositoryImplTest {
                 listOf(StansEllerOpphør(StansType.STANS, LocalDate.of(2024, 1, 1), setOf(Avslagsårsak.BRUDD_PÅ_AKTIVITETSPLIKT_STANS)))
             )
         }
-        dataSource.transaction {
-            VedtattStansOpphørRepositoryImpl(it).lagre(
-                behandlingId,
-                listOf(StansEllerOpphør(StansType.OPPHØR, LocalDate.of(2024, 3, 1), setOf(Avslagsårsak.ORDINÆRKVOTE_BRUKT_OPP)))
-            )
-        }
 
-        val typer = dataSource.transaction { conn ->
-            conn.queryList("SELECT type FROM vedtatt_stans_opphor WHERE behandling_id = ?") {
-                setParams { setLong(1, behandlingId.id) }
-                setRowMapper { it.getString("type") }
-            }
-        }
-        assertThat(typer).containsExactly("OPPHØR")
+        val oppdatert = listOf(
+            StansEllerOpphør(StansType.OPPHØR, LocalDate.of(2024, 3, 1), setOf(Avslagsårsak.ORDINÆRKVOTE_BRUKT_OPP))
+        )
+        dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).lagre(behandlingId, oppdatert) }
+
+        val resultat = dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).hent(behandlingId) }
+
+        assertThat(resultat).usingRecursiveComparison().isEqualTo(oppdatert)
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/service/AvsluttetBehandlingServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/service/AvsluttetBehandlingServiceTest.kt
@@ -239,13 +239,9 @@ class AvsluttetBehandlingServiceTest {
             dataSource.transaction { FritaksvurderingRepositoryImpl(it).hentFritaksvurderinger(behandlingId) }
         assertThat(uthentetFritaksvurdering).isEqualTo(listOf(fritaksvurdering))
 
-        val antallStansOpphorLagret = dataSource.transaction { conn ->
-            conn.queryFirst("SELECT COUNT(*) AS count FROM vedtatt_stans_opphor WHERE behandling_id = ?") {
-                setParams { setLong(1, behandlingId.id) }
-                setRowMapper { it.getInt("count") }
-            }
-        }
-        assertThat(antallStansOpphorLagret).isEqualTo(1)
+        val uthentetVedtattStansOpphør =
+            dataSource.transaction { VedtattStansOpphørRepositoryImpl(it).hent(behandlingId) }
+        assertThat(uthentetVedtattStansOpphør).isEqualTo(listOf(vedtattStansOpphørPeriode))
 
         val uthentetTilkjentYtelse =
             dataSource.transaction { TilkjentYtelseRepository(it).hentTilkjentYtelse(1) }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -799,8 +799,14 @@ class FakeArbeidsopptrappingRepository : ArbeidsopptrappingperioderRepository {
 }
 
 class FakeVedtattStansOpphørRepository : VedtattStansOpphørRepository {
+    private val lagret = mutableMapOf<BehandlingId, List<StansEllerOpphør>>()
+
     override fun lagre(behandlingId: BehandlingId, vedtattStansOpphør: List<StansEllerOpphør>) {
+        lagret[behandlingId] = vedtattStansOpphør
     }
+
+    override fun hent(behandlingId: BehandlingId): List<StansEllerOpphør> =
+        lagret[behandlingId] ?: emptyList()
 }
 
 class FakeFritaksvurderingRepository : FritaksvurderingRepository {


### PR DESCRIPTION
Legger til `hent()` i `VedtattStansOpphørRepository` og implementasjon, slik at tester kan bruke repository-metoden istedenfor rå SQL-spørringer.

- `hent()` henter alle perioder for en behandling med en LEFT JOIN mot årsak-tabellen
- Tester i `VedtattStansOpphørRepositoryImplTest` og `AvsluttetBehandlingServiceTest` bruker nå `hent()`
- `FakeVedtattStansOpphørRepository` lagrer nå faktisk data i minnet