### PR TITLE
Fiks kritiske PII-funn (P1)

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/App.kt
@@ -276,7 +276,7 @@ private fun Application.statusPages() {
                 "Noe gikk galt. Exception-type: ${cause.javaClass} Query string: ${call.request.queryString()}",
                 cause
             )
-            call.respondText(text = "500: $cause", status = HttpStatusCode.InternalServerError)
+            call.respondText(text = "500: Internal Server Error", status = HttpStatusCode.InternalServerError)
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/aap/statistikk/integrasjoner/pdl/PdlGateway.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/integrasjoner/pdl/PdlGateway.kt
@@ -15,6 +15,7 @@ import no.nav.aap.komponenter.httpklient.httpclient.tokenprovider.azurecc.Client
 import no.nav.aap.statistikk.PrometheusProvider
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.security.MessageDigest
 import java.time.Duration
 
 private val logger = LoggerFactory.getLogger(PdlGateway::class.java)
@@ -61,7 +62,8 @@ class PdlGraphQLGateway :
     override fun hentPersoner(identer: List<String>): List<Person> {
         logger.debug("Henter ${identer.size} personer fra PDL.")
 
-        return pdlCache.get(identer.joinToString(",")) {
+        val cacheNøkkel = sha256(identer.sorted().joinToString(","))
+        return pdlCache.get(cacheNøkkel) {
             val graphQLRespons = client.post<Any, GraphQLRespons<PdlRespons>>(
                 URI.create(requiredConfigForKey("integrasjon.pdl.url")),
                 PostRequest(body = PdlRequest.hentPersonBolk(identer))
@@ -70,7 +72,7 @@ class PdlGraphQLGateway :
             val graphQLdata =
                 requireNotNull(graphQLRespons?.data) { "Ingen data på graphql-respons. Errors: ${graphQLRespons?.errors}" }
 
-            graphQLdata.hentPersonBolk.map { personBolk -> requireNotNull(personBolk.person) { "Fant ikke info om person ${personBolk.ident}" } }
+            graphQLdata.hentPersonBolk.map { personBolk -> requireNotNull(personBolk.person) { "Fant ikke info om person (ident maskert)" } }
         }
     }
 }
@@ -113,3 +115,8 @@ data class Adressebeskyttelse(
 enum class Gradering {
     FORTROLIG, STRENGT_FORTROLIG_UTLAND, STRENGT_FORTROLIG, UGRADERT
 }
+
+private fun sha256(input: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(input.toByteArray())
+        .joinToString("") { "%02x".format(it) }

--- a/app/src/main/kotlin/no/nav/aap/statistikk/skjerming/SkjermingService.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/skjerming/SkjermingService.kt
@@ -18,17 +18,11 @@ class SkjermingService(
                 .flatMap { it.adressebeskyttelse }
                 .any { it.gradering.erHemmelig() }
         } catch (e: HttpConnectTimeoutException) {
-            logger.error(
-                "Feilet kall til PDL (HttpConnectTimeoutException). Returnerer false for skjerming. Se stackTrace.",
-                e
-            )
-            false
+            logger.error("Feilet kall til PDL (HttpConnectTimeoutException). Kaster exception.", e)
+            throw e
         } catch (e: java.net.ConnectException) {
-            logger.error(
-                "Feilet kall til PDL (ConnectException). Returnerer false for skjerming. Se stackTrace.",
-                e
-            )
-            false
+            logger.error("Feilet kall til PDL (ConnectException). Kaster exception.", e)
+            throw e
         }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/pdl/SkjermingServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/pdl/SkjermingServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.aap.statistikk.skjerming.SkjermingService
 import no.nav.aap.statistikk.testutils.FakePdlGateway
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.net.http.HttpConnectTimeoutException
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -79,7 +80,7 @@ class SkjermingServiceTest {
             }
         })
 
-        org.junit.jupiter.api.assertThrows<HttpConnectTimeoutException> {
+        assertThrows<HttpConnectTimeoutException> {
             service.erSkjermet(behandling)
         }
     }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/pdl/SkjermingServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/pdl/SkjermingServiceTest.kt
@@ -1,8 +1,5 @@
 package no.nav.aap.statistikk.pdl
 
-import ch.qos.logback.classic.Logger
-import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.read.ListAppender
 import no.nav.aap.statistikk.behandling.*
 import no.nav.aap.statistikk.integrasjoner.pdl.PdlGateway
 import no.nav.aap.statistikk.person.Person
@@ -13,9 +10,7 @@ import no.nav.aap.statistikk.skjerming.SkjermingService
 import no.nav.aap.statistikk.testutils.FakePdlGateway
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.slf4j.LoggerFactory
 import java.net.http.HttpConnectTimeoutException
-import java.net.http.HttpTimeoutException
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
@@ -77,25 +72,15 @@ class SkjermingServiceTest {
     }
 
     @Test
-    fun `om pdl-kall feiler med timeout, returneres false med warning i logg`() {
-        val logger =
-            LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME) as Logger
-        val listAppender = ListAppender<ILoggingEvent>()
-
-        listAppender.start()
-
-        logger.addAppender(listAppender)
-
+    fun `om pdl-kall feiler med timeout, kastes exception`() {
         val service = SkjermingService(object : PdlGateway {
             override fun hentPersoner(identer: List<String>): List<no.nav.aap.statistikk.integrasjoner.pdl.Person> {
                 throw HttpConnectTimeoutException("oopsie")
             }
         })
 
-
-        val res = service.erSkjermet(behandling)
-
-        assertThat(res).isFalse()
-        assertThat(listAppender.list.map { it.message }).anySatisfy { assertThat(it).contains("Returnerer false for skjerming. Se stackTrace") }
+        org.junit.jupiter.api.assertThrows<HttpConnectTimeoutException> {
+            service.erSkjermet(behandling)
+        }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/TestUtils.kt
@@ -198,7 +198,7 @@ fun konstruerMotor(
         LagreAvsluttetBehandlingTilBigQueryJobb(bqYtelseRepository)
     return motor(
         dataSource = dataSource,
-        gatewayProvider = defaultGatewayProvider { },
+        gatewayProvider = defaultGatewayProvider { register<FakePdlGateway>() },
         jobber = listOf(
             lagreAvsluttetBehandlingTilBigQueryJobb,
             lagreOppgaveJobb,
@@ -239,7 +239,7 @@ fun konstruerManuellMotor(
             LagreTilbakekrevingHendelseJobb()
         ),
         repositoryRegistry = postgresRepositoryRegistry,
-        gatewayProvider = defaultGatewayProvider { },
+        gatewayProvider = defaultGatewayProvider { register<FakePdlGateway>() },
     )
 }
 


### PR DESCRIPTION
## Bakgrunn

Gjennomgang av personvernhåndtering avdekket fire kritiske funn (P1) som kan eksponere fødselsnummer i logger, heap-dumps og HTTP-responser, samt sende data for skjermede personer til BigQuery ved PDL-nedetid.

## Endringer

### 1. Hash cache-nøkkel i PDL-cache (`PdlGateway.kt`)
FNR ble lagret som ren tekst som cache-nøkkel i Caffeine-cachen, og kunne dukke opp i heap-dumps og GC-logging. Nøkkelen hashes nå med SHA-256.

### 2. Fjern FNR fra exception-melding (`PdlGateway.kt`)
`requireNotNull` kastet en exception med FNR i meldingen. Erstattet med `"(ident maskert)"`.

### 3. Kast exception ved PDL-nedetid (`SkjermingService.kt`)
Ved `HttpConnectTimeoutException` og `ConnectException` returnerte tjenesten `false` (ikke skjermet), noe som kunne sende en skjermet persons data til BigQuery. Kaster nå exception slik at jobben feiler og kan kjøres på nytt.

### 4. Fjern exception-innhold fra HTTP 500-respons (`App.kt`)
`$cause` i feilresponsen kunne inneholde FNR fra exception-meldingen i punkt 2. Returnerer nå generisk `"500: Internal Server Error"`.