### PR TITLE
Revert: fjern direktecommit av audit-logging til main

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -78,12 +78,6 @@ spec:
         flags:
           - name: cloudsql.logical_decoding
             value: "on"
-          {{#unless isdev}}
-          - name: cloudsql.enable_pgaudit
-            value: "on"
-          - name: pgaudit.log
-            value: "all"
-          {{/unless}}
         tier: db-custom-1-3840
         diskAutoresize: true
         highAvailability: true


### PR DESCRIPTION
Commit 4291b17e ble pushet direkte til main. Denne PR-en reverter det slik at endringen kan gå gjennom PR-prosessen via #audit-logging-db.