### PR TITLE
Skru på audit-logging i db i prod

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -78,6 +78,12 @@ spec:
         flags:
           - name: cloudsql.logical_decoding
             value: "on"
+          {{#unless isdev}}
+          - name: cloudsql.enable_pgaudit
+            value: "on"
+          - name: pgaudit.log
+            value: "all"
+          {{/unless}}
         tier: db-custom-1-3840
         diskAutoresize: true
         highAvailability: true


### PR DESCRIPTION
Aktiverer pgAudit for Cloud SQL PostgreSQL-instansen kun i prod-miljøet.

## Endringer
- `cloudsql.enable_pgaudit = on` — aktiverer pgAudit-utvidelsen
- `pgaudit.log = all` — logger alle DB-operasjoner

Wrap med `{{#unless isdev}}` slik at det kun gjelder prod.

**Merk:** Merge revert-PR-en først, deretter denne.