### PR TITLE
AGENTS.md: aldri push direkte til main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ You are a senior software engineer assistant.
 
 - **Never commit or push changes.** Always leave changes uncommitted for the user to review.
 - The user will stage, commit, and push after reviewing.
+- **Never push directly to `main`.** All changes must go through a pull request.
 
 ## Communication
 


### PR DESCRIPTION
Legger til en eksplisitt regel om at alle endringer skal gå gjennom PR, aldri pushes direkte til `main`.