### PR TITLE
Legg til samordning- og graderingsfelter i BigQuery-view for tilkjent ytelse

### DIFF
--- a/.nais/bigquery/view_tilkjent_ytelse.yml
+++ b/.nais/bigquery/view_tilkjent_ytelse.yml
@@ -29,6 +29,13 @@ spec:
         tp.barnetillegg_sats as barnetillegg_sats,
         tp.redusert_dagsats as redusert_dagsats,
         tp.minstesats as minstesats,
+        tp.barnepensjon_dagsats as barnepensjon_dagsats,
+        tp.samordning_gradering as samordning_gradering,
+        tp.institusjon_gradering as institusjon_gradering,
+        tp.arbeid_gradering as arbeid_gradering,
+        tp.samordning_uforegradering as samordning_uforegradering,
+        tp.samordning_arbeidsgiver_gradering as samordning_arbeidsgiver_gradering,
+        tp.meldeplikt_gradering as meldeplikt_gradering,
         DATETIME(ty.opprettet_tidspunkt) AS reg_dato,
         DATETIME(TIMESTAMP_MILLIS(GREATEST(b.datastream_metadata.source_timestamp, tp.datastream_metadata.source_timestamp, ty.datastream_metadata.source_timestamp, br.datastream_metadata.source_timestamp, s.datastream_metadata.source_timestamp)), 'Europe/Oslo') AS endret_tid,
         concat(b.id, '-', tp.id, '-', ty.id, '-', br.id, '-', s.id) as unik_id


### PR DESCRIPTION
Legger til de 7 nye kolonnene fra PR #780 i BigQuery-viewet:

- `barnepensjon_dagsats`
- `samordning_gradering`
- `institusjon_gradering`
- `arbeid_gradering`
- `samordning_uforegradering`
- `samordning_arbeidsgiver_gradering`
- `meldeplikt_gradering`

Avhenger av at PR #780 er merget og deployet slik at kolonnene finnes i databasen.