### PR TITLE
Legg til view_gyldige_behandlinger som delt filter-view

### DIFF
--- a/.github/workflows/deploy_bigquery.yml
+++ b/.github/workflows/deploy_bigquery.yml
@@ -19,6 +19,7 @@ jobs:
         env:
           CLUSTER: ${{ inputs.cluster }}
           RESOURCE: "\
+            .nais/bigquery/view_gyldige_behandlinger.yml,\
             .nais/bigquery/view_vilkarsresultat.yml,\
             .nais/bigquery/view_tilkjent_ytelse.yml,\
             .nais/bigquery/view_beregningsgrunnlag.yml,\

--- a/.nais/bigquery/view_gyldige_behandlinger.yml
+++ b/.nais/bigquery/view_gyldige_behandlinger.yml
@@ -1,0 +1,37 @@
+apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+kind: BigQueryTable
+metadata:
+  name: view-gyldige-behandlinger
+  namespace: aap
+  labels:
+    team: aap
+  annotations:
+    cnrm.cloud.google.com/management-conflict-prevention-policy: none
+    cnrm.cloud.google.com/state-into-spec: absent
+    cnrm.cloud.google.com/project-id: {{project}}
+spec:
+  resourceID: view_gyldige_behandlinger
+  description: "Hjelperview som filtrerer frem gyldige behandlinger. Brukes av andre views for konsistent filtrering."
+  datasetRef:
+    external: ytelsestatistikk
+  view:
+    useLegacySql: false
+    query: >-
+      SELECT
+        b.id AS behandling_id,
+        bh.id AS bh_id
+      FROM
+        `datastream_hendelser.public_behandling` b
+      JOIN
+        `datastream_hendelser.public_behandling_historikk` bh
+      ON
+        bh.behandling_id = b.id
+      WHERE
+        bh.gjeldende = TRUE
+        AND (bh.slettet IS FALSE
+          OR bh.slettet IS NULL)
+        AND bh.status = 'AVSLUTTET'
+        AND (bh.resultat NOT IN ('TRUKKET', 'AVBRUTT',
+            'KLAGE_TRUKKET')
+          OR bh.resultat IS NULL)
+        AND b.type NOT IN ('Oppfølgingsbehandling')

--- a/.nais/bigquery/view_gyldige_behandlinger.yml
+++ b/.nais/bigquery/view_gyldige_behandlinger.yml
@@ -11,7 +11,7 @@ metadata:
     cnrm.cloud.google.com/project-id: {{project}}
 spec:
   resourceID: view_gyldige_behandlinger
-  description: "Hjelperview som filtrerer frem gyldige behandlinger. Brukes av andre views for konsistent filtrering."
+  description: "View som filtrerer behandlinger til ytelsesstatistikk. Kun vedtatte innvilgede behandlinger er interessant. Brukes av andre views for konsistent filtrering."
   datasetRef:
     external: ytelsestatistikk
   view:


### PR DESCRIPTION
## Beskrivelse

Legger til et nytt hjelperview `view_gyldige_behandlinger` i `ytelsestatistikk`-datasettet.

Dette view-et kapsler inn filtreringsbetingelsene som skal gjelde for gyldige behandlinger (tilsvarende filteret som allerede finnes i `view_behandlinger`):

- `bh.gjeldende = TRUE`
- `bh.slettet IS FALSE OR NULL`
- `bh.status = 'AVSLUTTET'`
- `bh.resultat NOT IN ('TRUKKET', 'AVBRUTT', 'KLAGE_TRUKKET')`
- `b.type NOT IN ('Oppfølgingsbehandling')`

View-et eksponerer `behandling_id` og `bh_id` slik at andre views kan JOINe mot det for konsistent filtrering uten å duplisere logikken.

Dette er en forutsetning for en påfølgende PR som oppdaterer de øvrige views (`view_beregningsgrunnlag`, `view_vilkarsresultat`, `view_tilkjent_ytelse`, `view_utbetaling`, `view_meldekort`) til å bruke dette felles filteret.