### PR TITLE
Bruk view_gyldige_behandlinger for konsistent filtrering i alle views

### DIFF
--- a/.nais/bigquery/view_behandlinger.yml
+++ b/.nais/bigquery/view_behandlinger.yml
@@ -95,9 +95,13 @@ spec:
      ON
         b.referanse_id = br.id
      JOIN
+       `ytelsestatistikk.view_gyldige_behandlinger` gyldig
+     ON
+       gyldig.behandling_id = b.id
+     JOIN
        `datastream_hendelser.public_behandling_historikk` bh
      ON
-       bh.behandling_id = b.id
+       bh.id = gyldig.bh_id
      JOIN
        `datastream_hendelser.public_person` p
      ON
@@ -114,13 +118,4 @@ spec:
        vedtatt_stans_opphor_agg vso_agg
      ON
        vso_agg.behandling_id = b.id
-     WHERE
-       bh.gjeldende = TRUE
-       AND (bh.slettet IS FALSE
-         OR bh.slettet IS NULL )
-       AND bh.status = 'AVSLUTTET'
-       AND (bh.resultat NOT IN ('TRUKKET', 'AVBRUTT',
-           'KLAGE_TRUKKET')
-         OR bh.resultat IS NULL)
-       AND b.type NOT IN ('Oppfølgingsbehandling')
     

--- a/.nais/bigquery/view_beregningsgrunnlag.yml
+++ b/.nais/bigquery/view_beregningsgrunnlag.yml
@@ -86,6 +86,10 @@ spec:
         ON
           b.id = pg.behandling_id
       JOIN
+        `ytelsestatistikk.view_gyldige_behandlinger` gyldig
+        ON
+          gyldig.behandling_id = b.id
+      JOIN
         datastream_hendelser.public_behandling_referanse br
         ON
           b.referanse_id = br.id

--- a/.nais/bigquery/view_meldekort.yml
+++ b/.nais/bigquery/view_meldekort.yml
@@ -30,6 +30,10 @@ spec:
       ON
         b.id = m.behandling_id
       JOIN
+        `ytelsestatistikk.view_gyldige_behandlinger` gyldig
+      ON
+        gyldig.behandling_id = b.id
+      JOIN
         `datastream_hendelser.public_behandling_referanse` br
       ON
         b.referanse_id = br.id

--- a/.nais/bigquery/view_tilkjent_ytelse.yml
+++ b/.nais/bigquery/view_tilkjent_ytelse.yml
@@ -50,6 +50,10 @@ spec:
       ON
         ty.behandling_id = b.id
       JOIN
+        `ytelsestatistikk.view_gyldige_behandlinger` gyldig
+      ON
+        gyldig.behandling_id = b.id
+      JOIN
         `datastream_hendelser.public_behandling_referanse` br
       ON
         b.referanse_id = br.id

--- a/.nais/bigquery/view_utbetaling.yml
+++ b/.nais/bigquery/view_utbetaling.yml
@@ -45,25 +45,14 @@ spec:
         ON
           b.referanse_id = br.id
       JOIN
+        `ytelsestatistikk.view_gyldige_behandlinger` gyldig
+        ON
+          gyldig.behandling_id = b.id
+      JOIN
         `datastream_hendelser.public_behandling_historikk` bh
         ON
-          bh.behandling_id = b.id
+          bh.id = gyldig.bh_id
       JOIN
         `datastream_hendelser.public_person` p
         ON
           p.id = s.person_id
-      WHERE
-        bh.gjeldende = TRUE
-        AND (
-          bh.slettet IS FALSE
-          OR bh.slettet IS NULL)
-        AND b.type IN (
-          'Førstegangsbehandling',
-          'Revurdering')
-        AND bh.status = 'AVSLUTTET'
-        AND (
-          bh.resultat NOT IN (
-            'TRUKKET', 'AVBRUTT',
-            'KLAGE_TRUKKET')
-          OR bh.resultat IS NULL)
-        AND b.type NOT IN ('Oppfølgingsbehandling')

--- a/.nais/bigquery/view_vilkarsresultat.yml
+++ b/.nais/bigquery/view_vilkarsresultat.yml
@@ -40,5 +40,6 @@ spec:
                LEFT JOIN `datastream_hendelser.public_vilkar` v ON vr.id = v.vilkarresult_id
                join `datastream_hendelser.public_vilkarsperiode` vp on v.id = vp.vilkar_id
                LEFT JOIN `datastream_hendelser.public_behandling` b on vr.behandling_id = b.id
+               JOIN `ytelsestatistikk.view_gyldige_behandlinger` gyldig ON gyldig.behandling_id = b.id
                LEFT JOIN `datastream_hendelser.public_behandling_referanse` br on b.referanse_id = br.id
                LEFT JOIN `datastream_hendelser.public_sak` s on s.id = b.sak_id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,10 @@ Never use kontrakt (e.g. `behandlingsflyt.kontrakt`) types directly in domain lo
 - If two consecutive events differ ONLY in these ignored fields, the second one is NOT saved
 - This means if only `saksbehandler` or `ansvarligEnhetKode` changes, a new event IS created
 - But if saksbehandler stays the same across multiple behandling state changes, only the first is saved
+
+### BigQuery Views
+
+When adding a new BigQuery view under `.nais/bigquery/`:
+
+- **Always add the new view to `.github/workflows/deploy_bigquery.yml`** under the `RESOURCE` list.
+- Deployment order matters: views that are referenced by other views must appear **before** those views in the list.


### PR DESCRIPTION
## Beskrivelse

Avhenger av #782 (må merges først).

Oppdaterer alle views (unntatt `view_saksstatistikk` og `view_gjeldende_hendelser_saksstatistikk`) til å JOINe mot det nye `view_gyldige_behandlinger` i stedet for å ha egne WHERE-betingelser. Dette sikrer at alle views viser data for de samme gyldige behandlingene.

## Endringer

| View | Endring |
|------|---------|
| `view_behandlinger` | WHERE-klausul erstattet med JOIN mot filter-view |
| `view_beregningsgrunnlag` | Fikk JOIN mot filter-view (hadde ingen filtrering) |
| `view_vilkarsresultat` | Fikk JOIN mot filter-view (hadde ingen filtrering) |
| `view_tilkjent_ytelse` | Fikk JOIN mot filter-view (hadde ingen filtrering) |
| `view_utbetaling` | WHERE-klausul erstattet med JOIN mot filter-view |
| `view_meldekort` | Fikk JOIN mot filter-view (hadde ingen filtrering) |

Merk: `view_utbetaling` hadde tidligere en strengere filter (`b.type IN ('Førstegangsbehandling', 'Revurdering')`). Denne er harmonisert med det felles filteret (kun ekskluderer `Oppfølgingsbehandling`).