### PR TITLE
Dedupliser SaksStatistikkService-konstruksjon

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/LagreSakinfoTilBigQueryJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/LagreSakinfoTilBigQueryJobb.kt
@@ -11,7 +11,6 @@ import no.nav.aap.motor.ProvidersJobbSpesifikasjon
 import no.nav.aap.statistikk.LoggingKontekst
 import no.nav.aap.statistikk.behandling.BehandlingId
 import no.nav.aap.statistikk.behandling.BehandlingRepository
-import no.nav.aap.statistikk.hendelser.BehandlingService
 import no.nav.aap.statistikk.jobber.appender.JobbAppender
 import no.nav.aap.statistikk.jobber.appender.MotorJobbAppender
 import org.slf4j.LoggerFactory
@@ -132,17 +131,7 @@ class LagreSakinfoTilBigQueryJobb : ProvidersJobbSpesifikasjon {
         repositoryProvider: RepositoryProvider,
         gatewayProvider: GatewayProvider
     ): JobbUtfører {
-        val behandlingService = BehandlingService(repositoryProvider, gatewayProvider)
-        val sakStatistikkService = SaksStatistikkService(
-            behandlingService = behandlingService,
-            sakstatistikkRepository = repositoryProvider.provide(),
-            bqBehandlingMapper = BQBehandlingMapper(
-                behandlingService = behandlingService,
-                rettighetstypeperiodeRepository = repositoryProvider.provide(),
-                oppgaveRepository = repositoryProvider.provide(),
-                sakstatistikkEventSourcing = SakstatistikkEventSourcing(),
-            ),
-        )
+        val sakStatistikkService = lagSaksStatistikkService(repositoryProvider, gatewayProvider)
         return LagreSakinfoTilBigQueryJobbUtfører(
             sakStatistikkService,
             MotorJobbAppender(),

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/ResendSakstatistikkJobb.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/ResendSakstatistikkJobb.kt
@@ -6,7 +6,6 @@ import no.nav.aap.motor.JobbInput
 import no.nav.aap.motor.JobbUtfører
 import no.nav.aap.motor.ProvidersJobbSpesifikasjon
 import no.nav.aap.statistikk.behandling.BehandlingId
-import no.nav.aap.statistikk.hendelser.BehandlingService
 import org.slf4j.LoggerFactory
 
 class ResendSakstatistikkJobbUtfører(
@@ -35,19 +34,8 @@ class ResendSakstatistikkJobb : ProvidersJobbSpesifikasjon {
         repositoryProvider: RepositoryProvider,
         gatewayProvider: GatewayProvider
     ): JobbUtfører {
-        val behandlingService = BehandlingService(repositoryProvider, gatewayProvider)
-        val sakStatistikkService = SaksStatistikkService(
-            behandlingService = behandlingService,
-            sakstatistikkRepository = repositoryProvider.provide(),
-            bqBehandlingMapper = BQBehandlingMapper(
-                behandlingService = behandlingService,
-                rettighetstypeperiodeRepository = repositoryProvider.provide(),
-                oppgaveRepository = repositoryProvider.provide(),
-                sakstatistikkEventSourcing = SakstatistikkEventSourcing(),
-            ),
-        )
         return ResendSakstatistikkJobbUtfører(
-            sakStatikkService = sakStatistikkService,
+            sakStatikkService = lagSaksStatistikkService(repositoryProvider, gatewayProvider),
         )
     }
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceFactory.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SaksStatistikkServiceFactory.kt
@@ -1,0 +1,22 @@
+package no.nav.aap.statistikk.saksstatistikk
+
+import no.nav.aap.komponenter.gateway.GatewayProvider
+import no.nav.aap.komponenter.repository.RepositoryProvider
+import no.nav.aap.statistikk.hendelser.BehandlingService
+
+internal fun lagSaksStatistikkService(
+    repositoryProvider: RepositoryProvider,
+    gatewayProvider: GatewayProvider,
+): SaksStatistikkService {
+    val behandlingService = BehandlingService(repositoryProvider, gatewayProvider)
+    return SaksStatistikkService(
+        behandlingService = behandlingService,
+        sakstatistikkRepository = repositoryProvider.provide(),
+        bqBehandlingMapper = BQBehandlingMapper(
+            behandlingService = behandlingService,
+            rettighetstypeperiodeRepository = repositoryProvider.provide(),
+            oppgaveRepository = repositoryProvider.provide(),
+            sakstatistikkEventSourcing = SakstatistikkEventSourcing(),
+        ),
+    )
+}


### PR DESCRIPTION
## Bakgrunn

Punkt 3 fra arkitekturgjennomgangen i `review.md`.

`LagreSakinfoTilBigQueryJobb.konstruer()` og `ResendSakstatistikkJobb.konstruer()` hadde identisk kode for å bygge en `SaksStatistikkService`.

## Endringer

Trekker ut en felles intern hjelpefunksjon `lagSaksStatistikkService()` i en ny fil `SaksStatistikkServiceFactory.kt`. Begge jobb-klassene bruker nå denne funksjonen.

**Gevinst:** Endringer i oppbygging av `SaksStatistikkService` gjøres heretter kun ett sted.