### PR TITLE
Logg advarsel når saksbehandler har hatt annen behandlingmetode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,6 @@ Chat with the user in English. Code comments and commit messages should be in No
 
 Known terms (Norwegian): "bug" (not "bugg").
 
-Known terms (Norwegian): "bug" (not "bugg").
-
 ## Coding Guidelines
 
 - **Never store temporary files in /tmp** — this includes PR body files, debug output, scripts, etc.
@@ -66,6 +64,7 @@ For testing, prefer in-memory fakes over mocks. Fakes provide:
 - **Never use --no-daemon** when running Gradle tests or builds - it's slower
 - The Gradle daemon improves build performance through caching and hot JVM
 - **Always run `./gradlew test` after making code changes** to ensure all tests pass. While working, run tests on relevant files to save time.
+- **Run `./gradlew test` when done with a task** — do not consider a task complete without verified passing tests.
 - **Run `./gradlew detektMain` after significant code changes** to check code quality
 - Fix any Detekt violations before committing
 - Compiling alone is not sufficient — always run the full test suite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,7 @@ For testing, prefer in-memory fakes over mocks. Fakes provide:
 - The Gradle daemon improves build performance through caching and hot JVM
 - **Always run `./gradlew test` after making code changes** to ensure all tests pass. While working, run tests on relevant files to save time.
 - **Run `./gradlew test` when done with a task** — do not consider a task complete without verified passing tests.
-- **Run `./gradlew detektMain` after significant code changes** to check code quality
-- Fix any Detekt violations before committing
+- **Run `./gradlew detektMain` after significant code changes** to check code quality. Fix any new violations introduced by your changes before committing — pre-existing violations can be left as-is.
 - Compiling alone is not sufficient — always run the full test suite
 - **Do not mark a task complete without having run and verified tests pass**
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/behandling/Behandling.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/behandling/Behandling.kt
@@ -171,15 +171,11 @@ data class Behandling(
 
         val sisteDefinisjon = Definisjon.forKode(sisteHendelse.avklaringsBehov)
 
-        if (sisteDefinisjon == Definisjon.KVALITETSSIKRING) {
-            return BehandlingMetode.KVALITETSSIKRING
+        return when (sisteDefinisjon.tilBehandlingMetode()) {
+            BehandlingMetode.KVALITETSSIKRING -> BehandlingMetode.KVALITETSSIKRING
+            BehandlingMetode.FATTE_VEDTAK -> BehandlingMetode.FATTE_VEDTAK
+            else -> if (this.hendelser.erManuell()) BehandlingMetode.MANUELL else BehandlingMetode.AUTOMATISK
         }
-
-        if (sisteDefinisjon == Definisjon.FATTE_VEDTAK) {
-            return BehandlingMetode.FATTE_VEDTAK
-        }
-
-        return if (this.hendelser.erManuell()) BehandlingMetode.MANUELL else BehandlingMetode.AUTOMATISK
     }
 }
 
@@ -188,6 +184,13 @@ private fun List<BehandlingHendelse>.erManuell(): Boolean {
     return this.filterNot { it.avklaringsBehov == null }.any {
         !Definisjon.forKode(requireNotNull(it.avklaringsBehov)).erAutomatisk()
     }
+}
+
+fun Definisjon.tilBehandlingMetode(): BehandlingMetode = when {
+    this == Definisjon.KVALITETSSIKRING -> BehandlingMetode.KVALITETSSIKRING
+    this == Definisjon.FATTE_VEDTAK -> BehandlingMetode.FATTE_VEDTAK
+    this.erAutomatisk() -> BehandlingMetode.AUTOMATISK
+    else -> BehandlingMetode.MANUELL
 }
 
 /**

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
@@ -67,8 +67,8 @@ class BQBehandlingMapper(
         if (!erSkjermet && saksbehandler != null) {
             val tidligereBehandlingMetoderForSaksbehandler = snapshots
                 .dropLast(1)
-                .filter { it.saksbehandler == saksbehandler && it.avklaringsbehov != null }
-                .map { avklaringsbehovTilBehandlingMetode(it.avklaringsbehov!!) }
+                .filter { it.saksbehandler == saksbehandler }
+                .mapNotNull { snapshot -> snapshot.avklaringsbehov?.let { avklaringsbehovTilBehandlingMetode(it) } }
                 .filter { it != behandlingMetode }
                 .toSet()
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/BQBehandlingMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.statistikk.saksstatistikk
 
+import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.komponenter.gateway.GatewayProvider
 import no.nav.aap.statistikk.KELVIN
 import no.nav.aap.statistikk.PrometheusProvider
@@ -61,6 +62,25 @@ class BQBehandlingMapper(
         val saksbehandler =
             if (erSkjermet) SKJERMET_ENHET else utledSaksbehandler(behandling, snapshots)
 
+        // Advarsel: samme saksbehandler har hatt en annen behandlingmetode tidligere i denne behandlingen
+        val behandlingMetode = behandling.behandlingMetode()
+        if (!erSkjermet && saksbehandler != null) {
+            val tidligereBehandlingMetoderForSaksbehandler = snapshots
+                .dropLast(1)
+                .filter { it.saksbehandler == saksbehandler && it.avklaringsbehov != null }
+                .map { avklaringsbehovTilBehandlingMetode(it.avklaringsbehov!!) }
+                .filter { it != behandlingMetode }
+                .toSet()
+
+            if (tidligereBehandlingMetoderForSaksbehandler.isNotEmpty()) {
+                log.warn(
+                    "Saksbehandler $saksbehandler har hatt behandlingmetode $behandlingMetode, " +
+                            "men hadde tidligere $tidligereBehandlingMetoderForSaksbehandler for behandling $behandlingReferanse. " +
+                            "Mulig feil i saksbehandler-utledning."
+                )
+            }
+        }
+
         val årsakTilOpprettelse = behandling.årsakTilOpprettelse
         if (årsakTilOpprettelse == null) {
             log.info("Årsak til opprettelse er ikke satt. Behandling: $behandlingReferanse. Sak: ${sak.saksnummer}.")
@@ -78,7 +98,8 @@ class BQBehandlingMapper(
             ansvarligEnhet = ansvarligEnhet,
             saksbehandler = saksbehandler,
             endretTid = snapshots.last().tidspunkt,
-            behandlingStatus = behandlingStatus(behandling)
+            behandlingStatus = behandlingStatus(behandling),
+            behandlingMetode = behandlingMetode,
         )
     }
 
@@ -89,7 +110,8 @@ class BQBehandlingMapper(
         ansvarligEnhet: String?,
         saksbehandler: String?,
         endretTid: LocalDateTime,
-        behandlingStatus: String
+        behandlingStatus: String,
+        behandlingMetode: BehandlingMetode,
     ): BQBehandling {
         val årsakTilOpprettelse = behandling.årsakTilOpprettelse
         val sak = behandling.sak
@@ -116,7 +138,7 @@ class BQBehandlingMapper(
             vedtakTid = behandling.vedtakstidspunkt(),
             søknadsFormat = behandling.søknadsformat,
             saksbehandler = saksbehandler,
-            behandlingMetode = behandling.behandlingMetode().also {
+            behandlingMetode = behandlingMetode.also {
                 if (it == BehandlingMetode.AUTOMATISK) log.info(
                     "Behandling $behandlingReferanse er automatisk behandlet. Behandlingtype ${behandling.typeBehandling}"
                 )
@@ -231,6 +253,9 @@ class BQBehandlingMapper(
             }
         }
     }
+
+    private fun avklaringsbehovTilBehandlingMetode(avklaringsbehov: String): BehandlingMetode =
+        Definisjon.forKode(avklaringsbehov).tilBehandlingMetode()
 
     data class EnhetOgSaksbehandler(val enhet: String?, val saksbehandler: String?)
 


### PR DESCRIPTION
## Hva

Legger til en `WARN`-logg i `BQBehandlingMapper` som utløses når saksbehandleren i en BQ-rad tidligere har hatt en annen behandlingmetode for samme behandling.

Dette er en deteksjonsmekanisme for feilen fikset i #794, der saksbehandler i KVALITETSSIKRING feilaktig ble satt til personen fra forrige steg.

## Hvordan

- Sjekker alle tidligere snapshots for behandlingen: hvis samme saksbehandler dukker opp med en annen behandlingmetode, logges en advarsel
- Ekstraherer `Definisjon.tilBehandlingMetode()` som felles hjelpefunksjon — brukes både i `Behandling.behandlingMetode()` og i den nye sjekken, slik at logikken ikke dupliseres
- Oppdaterer `AGENTS.md`: kjør alltid `./gradlew test` når en oppgave er ferdig

## Eksempel på loggmelding

```
WARN Saksbehandler B144259 har hatt behandlingmetode KVALITETSSIKRING, men hadde tidligere [MANUELL] for behandling 39caa711-.... Mulig feil i saksbehandler-utledning.
```