### PR TITLE
Unngå falske positive advarsler om saksbehandler-behandlingmetode

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkEventSourcing.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/saksstatistikk/SakstatistikkEventSourcing.kt
@@ -1,5 +1,6 @@
 package no.nav.aap.statistikk.saksstatistikk
 
+import no.nav.aap.behandlingsflyt.kontrakt.avklaringsbehov.Definisjon
 import no.nav.aap.statistikk.behandling.Behandling
 import no.nav.aap.statistikk.oppgave.HendelseType
 import no.nav.aap.statistikk.oppgave.Oppgave
@@ -24,15 +25,27 @@ class SakstatistikkEventSourcing {
 
     private fun konverterBehandlingHendelser(behandling: Behandling): List<SakstatistikkHendelse> {
         return behandling.hendelser.map { hendelse ->
+            val rolleEndret = rolleEndretMellom(hendelse.sisteLøsteAvklaringsbehov, hendelse.avklaringsBehov)
             BehandlingsflytHendelse(
                 behandlingReferanse = behandling.referanse,
                 tidspunkt = hendelse.hendelsesTidspunkt,
                 status = hendelse.status.name,
                 avklaringsbehov = hendelse.avklaringsBehov,
                 sisteLøsteAvklaringsbehov = hendelse.sisteLøsteAvklaringsbehov,
-                sisteSaksbehandlerPåBehandling = hendelse.sisteSaksbehandlerSomLøstebehov
+                sisteSaksbehandlerPåBehandling = if (rolleEndret) null else hendelse.sisteSaksbehandlerSomLøstebehov
             )
         }
+    }
+
+    /**
+     * Returnerer true dersom avklaringsbehovene løses av ulike roller, slik at saksbehandler-fallback
+     * ikke skal bæres over fra ett steg til et annet.
+     */
+    private fun rolleEndretMellom(forrigeAvklaringsbehov: String?, nyttAvklaringsbehov: String?): Boolean {
+        if (forrigeAvklaringsbehov == null || nyttAvklaringsbehov == null) return false
+        val forrigeRoller = Definisjon.forKode(forrigeAvklaringsbehov).løsesAv.toSet()
+        val nyeRoller = Definisjon.forKode(nyttAvklaringsbehov).løsesAv.toSet()
+        return forrigeRoller.intersect(nyeRoller).isEmpty()
     }
 
     private fun konverterOppgaveHendelser(oppgaver: List<Oppgave>): List<SakstatistikkHendelse> {


### PR DESCRIPTION
## Problem

Advarselen _«Saksbehandler $saksbehandler har hatt behandlingmetode MANUELL, men hadde tidligere [KVALITETSSIKRING]»_ gav falske positive.

## Årsak

`sisteSaksbehandlerSomLøstebehov` (en MANUELL-person) ble alltid sendt med som `sisteSaksbehandlerPåBehandling` i `BehandlingsflytHendelse`, også ved overgang til steg med en helt annen rolle (f.eks. MANUELL → KVALITETSSIKRING). Fallback-logikken i `SakstatistikkState` plukket da opp MANUELL-personen som saksbehandler i KVALITETSSIKRING-snapshots, og advarselen ble trigget feilaktig.

## Løsning

Bruker `Definisjon.løsesAv` til å sammenligne rollene mellom `sisteLøsteAvklaringsbehov` og nytt `avklaringsBehov`. Hvis rollene ikke overlapper (dvs. rollen har endret seg), settes `sisteSaksbehandlerPåBehandling = null` slik at foreldet saksbehandler ikke bæres inn i neste stegs snapshot.