### PR TITLE
Raskere testisolasjon: erstatt flyway clean+migrate med TRUNCATE

### DIFF
--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/WithBigQueryContainer.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/WithBigQueryContainer.kt
@@ -23,7 +23,7 @@ import java.util.*
 )
 annotation class BigQuery
 
-class BigQueryExtension : ParameterResolver, AfterAllCallback {
+class BigQueryExtension : ParameterResolver {
 
     companion object {
         private val bigQueryContainer =
@@ -87,7 +87,4 @@ class BigQueryExtension : ParameterResolver, AfterAllCallback {
         return testBigQueryConfig()
     }
 
-    override fun afterAll(context: ExtensionContext) {
-        bigQueryContainer.stop()
-    }
 }

--- a/app/src/test/kotlin/no/nav/aap/statistikk/testutils/WithPostgresContainer.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/testutils/WithPostgresContainer.kt
@@ -41,6 +41,7 @@ class WithPostgresContainer : AfterEachCallback, BeforeEachCallback, ParameterRe
         private var dataSource: HikariDataSource
         private val flyway: Migrering
         private val dbConfig: DbConfig
+        private lateinit var truncateStatement: String
 
         init {
             System.setProperty("flyway.cleanDisabled", false.toString())
@@ -53,17 +54,32 @@ class WithPostgresContainer : AfterEachCallback, BeforeEachCallback, ParameterRe
             )
             flyway = Migrering(dbConfig)
             dataSource = flyway.createAndMigrateDataSource()
+            truncateStatement = buildTruncateStatement()
+        }
+
+        private fun buildTruncateStatement(): String {
+            dataSource.connection.use { conn ->
+                val result = conn.metaData.getTables(null, "public", null, arrayOf("TABLE"))
+                val tables = buildList {
+                    while (result.next()) {
+                        val name = result.getString("TABLE_NAME")
+                        if (name != "flyway_schema_history" && !name.startsWith("kodeverk_")) {
+                            add("\"$name\"")
+                        }
+                    }
+                }
+                return "TRUNCATE TABLE ${tables.joinToString(", ")} RESTART IDENTITY CASCADE"
+            }
         }
     }
 
     override fun beforeEach(context: ExtensionContext) {
-        flyway.clean()
-        flyway.createAndMigrateDataSource()
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { it.execute(truncateStatement) }
+        }
     }
 
     override fun afterEach(context: ExtensionContext) {
-//            flyway.clean()
-//            flyway.createAndMigrateDataSource()
     }
 
     override fun supportsParameter(


### PR DESCRIPTION
## Hva

Erstatter den dyre testoppsett-mekanismen med en raskere variant.

### Postgres-isolasjon

**Tidligere:** `flyway.clean()` + `flyway.migrate()` kjørte før *hver enkelt test* — dette droppet alle tabeller og kjørte alle **190 migrasjonsfiler** på nytt for hvert testtilfelle.

**Nå:** En enkelt `TRUNCATE TABLE ... RESTART IDENTITY CASCADE`-setning nullstiller all testdata. Skjemaet opprettes én gang ved oppstart og gjenbrukes. TRUNCATE-setningen bygges én gang (ved å spørre `information_schema`) og caches som en statisk streng.

`kodeverk_*`-tabeller og `flyway_schema_history` ekskluderes fra truncation siden de inneholder seed-data fra migrasjoner.

### BigQuery-container livssyklus-bug

**Tidligere:** `BigQueryExtension` implementerte `AfterAllCallback` og kalte `bigQueryContainer.stop()` per testklasse. Siden containeren er en statisk singleton, ville den første klassen som fullførte stoppe containeren og bryte påfølgende klasser som bruker `@BigQuery`.

**Nå:** Fjernet `AfterAllCallback` helt. Testcontainers' Ryuk-reaper håndterer opprydding ved JVM-avslutning.

## Resultat

**~55s → ~31s (~44% raskere)**