### PR TITLE
Sett opp PrometheusRule-alarmer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,18 @@ jobs:
       manifest: .nais/nais.yaml
       vars: .nais/dev.yaml
 
+  alerts-dev:
+    if: github.event.pull_request.merged || github.event_name == 'push' || github.event.inputs.cluster == 'dev-gcp'
+    permissions:
+      contents: read
+      id-token: write
+    needs: gradle
+    uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
+    secrets: inherit
+    with:
+      cluster: dev-gcp
+      manifest: .nais/alerts.yaml
+
   prod:
     ## push til main eller etter branch (e.g. dependabot) er merget
     if: github.event.pull_request.merged || github.event_name == 'push' || github.event.inputs.cluster == 'prod-gcp'
@@ -66,6 +78,18 @@ jobs:
       cluster: prod-gcp
       manifest: .nais/nais.yaml
       vars: .nais/prod.yaml
+
+  alerts-prod:
+    if: github.event.pull_request.merged || github.event_name == 'push' || github.event.inputs.cluster == 'prod-gcp'
+    permissions:
+      contents: read
+      id-token: write
+    needs: prod
+    uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
+    secrets: inherit
+    with:
+      cluster: prod-gcp
+      manifest: .nais/alerts.yaml
 
   deploy-bigquery-resources-dev:
     uses: ./.github/workflows/deploy_bigquery.yml

--- a/.nais/alerts.yaml
+++ b/.nais/alerts.yaml
@@ -1,0 +1,77 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: statistikk-alerts
+  namespace: aap
+  labels:
+    team: aap
+spec:
+  groups:
+    - name: statistikk-infrastruktur
+      rules:
+        - alert: AppNede
+          expr: kube_deployment_status_replicas_available{namespace="aap", deployment="statistikk"} == 0
+          for: 5m
+          annotations:
+            summary: "statistikk har ingen tilgjengelige pods"
+            consequence: "Tjenesten er nede og ingen hendelser blir prosessert."
+            action: "`kubectl describe pod <podname> -n aap` -> `kubectl logs <podname> -n aap`"
+          labels:
+            namespace: aap
+            severity: critical
+
+        - alert: HøyMinnebruk
+          expr: |
+            sum(jvm_memory_used_bytes{app="statistikk", area="heap"})
+            /
+            sum(jvm_memory_max_bytes{app="statistikk", area="heap"})
+            * 100 > 85
+          for: 10m
+          annotations:
+            summary: "Høy JVM heap-bruk i statistikk"
+            consequence: "Applikasjonen kan krasje med OutOfMemoryError."
+            action: "Vurder å øke minnegrensen i nais.yaml eller undersøk minnelekkasje."
+          labels:
+            namespace: aap
+            severity: warning
+
+    - name: statistikk-http
+      rules:
+        - alert: HøyHTTPFeilrate
+          expr: |
+            sum(rate(http_server_request_duration_seconds_count{app="statistikk", http_response_status_code=~"5.."}[5m]))
+            /
+            sum(rate(http_server_request_duration_seconds_count{app="statistikk"}[5m]))
+            * 100 > 5
+          for: 5m
+          annotations:
+            summary: "Høy HTTP 5xx-feilrate i statistikk"
+            consequence: "Brukere og kallende systemer opplever feil."
+            action: "Sjekk logger med `kubectl logs -n aap -l app=statistikk --tail=100`"
+          labels:
+            namespace: aap
+            severity: warning
+
+    - name: statistikk-forretning
+      rules:
+        - alert: IngenNyeHendelser
+          expr: rate(statistikk_lagret_stoppet_hendelse_total{app="statistikk"}[30m]) == 0
+          for: 30m
+          annotations:
+            summary: "Ingen nye hendelser er lagret de siste 30 minuttene"
+            consequence: "Statistikkdata kan være utdatert. Oppstrøms systemer har muligens sluttet å sende hendelser."
+            action: "Sjekk at behandlingsflyt og andre oppstrøms systemer kjører og sender hendelser."
+          labels:
+            namespace: aap
+            severity: warning
+
+        - alert: ÅrsakTilOpprettelseIkkeSatt
+          expr: rate(statistikk_aarsak_til_opprettelse_ikke_satt_total{app="statistikk"}[10m]) > 0
+          for: 5m
+          annotations:
+            summary: "Behandlinger opprettes uten årsak til opprettelse"
+            consequence: "Datakvaliteten i statistikkgrunnlaget er redusert."
+            action: "Undersøk hvilke behandlinger som mangler årsak og sjekk oppstrøms kontrakt."
+          labels:
+            namespace: aap
+            severity: warning


### PR DESCRIPTION
## Hva

Legger til Prometheus-alarmer for `statistikk`-appen via en `PrometheusRule`-ressurs i `.nais/alerts.yaml`.

## Alarmer

| Alarm | Alvorlighet | Beskrivelse |
|-------|------------|-------------|
| `AppNede` | 🔴 critical | Ingen tilgjengelige pods i 5 min |
| `HøyMinnebruk` | 🟡 warning | JVM heap >85% i 10 min |
| `HøyHTTPFeilrate` | 🟡 warning | >5% HTTP 5xx-feil over 5 min |
| `IngenNyeHendelser` | 🟡 warning | Ingen hendelser lagret på 30 min (mulig problem oppstrøms) |
| `ÅrsakTilOpprettelseIkkeSatt` | 🟡 warning | Datakvalitetsproblem: behandlinger uten årsak til opprettelse |

Alarmer sendes til teamets Slack-kanal via Alertmanager.

## CI/CD

Oppdaterer `release.yaml` med egne deploy-steg (`alerts-dev` og `alerts-prod`) som deployer `alerts.yaml` til hhv. dev-gcp og prod-gcp.