### PR TITLE
Oppdatert tid for kildetabeller

### DIFF
--- a/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/RettighetstypeperiodeRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/RettighetstypeperiodeRepository.kt
@@ -2,9 +2,14 @@ package no.nav.aap.statistikk.avsluttetbehandling
 
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.repository.RepositoryFactory
+import java.time.Clock
+import java.time.LocalDateTime
 import java.util.*
 
-class RettighetstypeperiodeRepository(private val dbConnection: DBConnection) :
+class RettighetstypeperiodeRepository(
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) :
     IRettighetstypeperiodeRepository {
 
     companion object : RepositoryFactory<IRettighetstypeperiodeRepository> {
@@ -17,6 +22,7 @@ class RettighetstypeperiodeRepository(private val dbConnection: DBConnection) :
         behandlingReferanse: UUID,
         rettighetstypePeriode: List<RettighetstypePeriode>
     ) {
+        val oppdatertTid = LocalDateTime.now(clock)
         val deletePerioderSql = """
             DELETE FROM rettighetstypeperioder WHERE rettighetstype_id IN (
                 SELECT r.id FROM rettighetstype r
@@ -37,20 +43,22 @@ class RettighetstypeperiodeRepository(private val dbConnection: DBConnection) :
         dbConnection.execute(deleteRettighetstypeSql) { setParams { setUUID(1, behandlingReferanse) } }
 
         val sql = """
-            INSERT INTO rettighetstype (behandling_id)
+           INSERT INTO rettighetstype (behandling_id, oppdatert_tid)
 VALUES ((SELECT b.id
          FROM behandling b
                   join behandling_referanse br on b.referanse_id = br.id
-         WHERE br.referanse = ?));
+         WHERE br.referanse = ?),
+        ?);
         """.trimIndent()
         val key = dbConnection.executeReturnKey(sql) {
-            setParams {
-                setUUID(1, behandlingReferanse)
-            }
+           setParams {
+               setUUID(1, behandlingReferanse)
+               setLocalDateTime(2, oppdatertTid)
+           }
         }
 
         val sql2 = """
-            insert into rettighetstypeperioder (rettighetstype_id, fra_dato, til_dato, rettighetstype) values (?, ?, ?, ?);
+           insert into rettighetstypeperioder (rettighetstype_id, fra_dato, til_dato, rettighetstype) values (?, ?, ?, ?);
         """.trimIndent()
 
         dbConnection.executeBatch(sql2, rettighetstypePeriode) {

--- a/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/SamordningRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/avsluttetbehandling/SamordningRepositoryImpl.kt
@@ -3,8 +3,13 @@ package no.nav.aap.statistikk.avsluttetbehandling
 import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.behandling.BehandlingId
+import java.time.Clock
+import java.time.LocalDateTime
 
-class SamordningRepositoryImpl(private val dbConnection: DBConnection) : SamordningRepository {
+class SamordningRepositoryImpl(
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) : SamordningRepository {
 
     companion object : RepositoryFactory<SamordningRepositoryImpl> {
         override fun konstruer(connection: DBConnection): SamordningRepositoryImpl =
@@ -13,6 +18,7 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
 
     override fun lagre(behandlingId: BehandlingId, samordning: Samordning) {
         val id = behandlingId.id
+        val oppdatertTid = LocalDateTime.now(clock)
 
         dbConnection.execute("DELETE FROM samordning_ufore WHERE behandling_id = ?") {
             setParams { setLong(1, id) }
@@ -28,7 +34,7 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
         }
 
         dbConnection.executeBatch(
-            "INSERT INTO samordning_ufore (behandling_id, fra_dato, til_dato, grad) VALUES (?, ?, ?, ?)",
+            "INSERT INTO samordning_ufore (behandling_id, fra_dato, til_dato, grad, oppdatert_tid) VALUES (?, ?, ?, ?, ?)",
             samordning.uføre,
         ) {
             setParams {
@@ -36,11 +42,12 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
                 setLocalDate(2, it.fom)
                 setLocalDate(3, it.tom)
                 setInt(4, it.grad)
+                setLocalDateTime(5, oppdatertTid)
             }
         }
 
         dbConnection.executeBatch(
-            "INSERT INTO samordning_statlig_ytelse (behandling_id, fra_dato, til_dato, ytelse, prosent) VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO samordning_statlig_ytelse (behandling_id, fra_dato, til_dato, ytelse, prosent, oppdatert_tid) VALUES (?, ?, ?, ?, ?, ?)",
             samordning.statligeYtelser,
         ) {
             setParams {
@@ -49,11 +56,12 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
                 setLocalDate(3, it.tom)
                 setString(4, it.ytelse.name)
                 setInt(5, it.prosent)
+                setLocalDateTime(6, oppdatertTid)
             }
         }
 
         dbConnection.executeBatch(
-            "INSERT INTO samordning_avregning_andre_ytelser (behandling_id, fra_dato, til_dato, ytelse) VALUES (?, ?, ?, ?)",
+            "INSERT INTO samordning_avregning_andre_ytelser (behandling_id, fra_dato, til_dato, ytelse, oppdatert_tid) VALUES (?, ?, ?, ?, ?)",
             samordning.avregningAndreYtelser,
         ) {
             setParams {
@@ -61,17 +69,19 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
                 setLocalDate(2, it.fom)
                 setLocalDate(3, it.tom)
                 setString(4, it.ytelse.name)
+                setLocalDateTime(5, oppdatertTid)
             }
         }
 
         dbConnection.executeBatch(
-            "INSERT INTO samordning_arbeidsgiver (behandling_id, fra_dato, til_dato) VALUES (?, ?, ?)",
+            "INSERT INTO samordning_arbeidsgiver (behandling_id, fra_dato, til_dato, oppdatert_tid) VALUES (?, ?, ?, ?)",
             samordning.arbeidsgiver,
         ) {
             setParams {
                 setLong(1, id)
                 setLocalDate(2, it.fom)
                 setLocalDate(3, it.tom)
+                setLocalDateTime(4, oppdatertTid)
             }
         }
     }
@@ -148,4 +158,3 @@ class SamordningRepositoryImpl(private val dbConnection: DBConnection) : Samordn
         )
     }
 }
-

--- a/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnosePerioderRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnosePerioderRepositoryImpl.kt
@@ -5,7 +5,9 @@ import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.avsluttetbehandling.DiagnoseMedPeriode
 import java.util.*
 
-class DiagnosePerioderRepositoryImpl(private val dbConnection: DBConnection) :
+class DiagnosePerioderRepositoryImpl(
+    private val dbConnection: DBConnection,
+) :
     DiagnosePerioderRepository {
 
     companion object : RepositoryFactory<DiagnosePerioderRepository> {

--- a/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImpl.kt
@@ -4,6 +4,8 @@ import no.nav.aap.komponenter.dbconnect.DBConnection
 import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.avsluttetbehandling.Diagnoser
 import org.slf4j.LoggerFactory
+import java.time.Clock
+import java.time.LocalDateTime
 import java.util.*
 
 data class DiagnoseEntity(
@@ -24,7 +26,10 @@ data class DiagnoseEntity(
     }
 }
 
-class DiagnoseRepositoryImpl(private val dbConnection: DBConnection) : DiagnoseRepository {
+class DiagnoseRepositoryImpl(
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
+) : DiagnoseRepository {
     private val logger = LoggerFactory.getLogger(DiagnoseRepositoryImpl::class.java)
 
     companion object : RepositoryFactory<DiagnoseRepository> {
@@ -34,19 +39,22 @@ class DiagnoseRepositoryImpl(private val dbConnection: DBConnection) : DiagnoseR
     }
 
     override fun lagre(diagnoseEntity: DiagnoseEntity): Long {
+        val oppdatertTid = LocalDateTime.now(clock)
         val sql = """
-INSERT INTO DIAGNOSE (behandling_id, kodeverk, diagnosekode, bidiagnoser)
+INSERT INTO DIAGNOSE (behandling_id, kodeverk, diagnosekode, bidiagnoser, oppdatert_tid)
 VALUES ((SELECT b.id
          FROM behandling b
                   join behandling_referanse br on b.referanse_id = br.id
          WHERE br.referanse = ?),
         ?,
         ?,
+        ?,
         ?)
 ON CONFLICT (behandling_id) DO UPDATE SET
     kodeverk = EXCLUDED.kodeverk,
     diagnosekode = EXCLUDED.diagnosekode,
-    bidiagnoser = EXCLUDED.bidiagnoser;
+    bidiagnoser = EXCLUDED.bidiagnoser,
+    oppdatert_tid = EXCLUDED.oppdatert_tid;
 
         """.trimIndent()
 
@@ -56,6 +64,7 @@ ON CONFLICT (behandling_id) DO UPDATE SET
                 setString(2, diagnoseEntity.kodeverk)
                 setString(3, diagnoseEntity.diagnosekode)
                 setArray(4, diagnoseEntity.bidiagnoser)
+                setLocalDateTime(5, oppdatertTid)
             }
         }
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/beregningsgrunnlag/repository/BeregningsgrunnlagRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/beregningsgrunnlag/repository/BeregningsgrunnlagRepository.kt
@@ -9,6 +9,7 @@ import no.nav.aap.statistikk.avsluttetbehandling.IBeregningsGrunnlag
 import no.nav.aap.statistikk.avsluttetbehandling.MedBehandlingsreferanse
 import no.nav.aap.statistikk.avsluttetbehandling.UføreType
 import no.nav.aap.statistikk.behandling.BehandlingId
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Year
@@ -16,7 +17,8 @@ import java.util.*
 import kotlin.collections.orEmpty
 
 class BeregningsgrunnlagRepository(
-    private val dbConnection: DBConnection
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) : IBeregningsgrunnlagRepository {
     companion object : RepositoryFactory<IBeregningsgrunnlagRepository> {
         override fun konstruer(connection: DBConnection): IBeregningsgrunnlagRepository {
@@ -145,16 +147,18 @@ WHERE br.referanse = ?"""
         behandlingId: BehandlingId
     ): Long {
         val sql =
-            "INSERT INTO GRUNNLAG(type, behandling_id, opprettet_tidspunkt, beregningsaar, nedsatt_arbeidsevne_dato, ytterligere_nedsatt_arbeidsevne_dato) VALUES (?, ?, ?, ?, ?, ?) "
+            "INSERT INTO GRUNNLAG(type, behandling_id, opprettet_tidspunkt, beregningsaar, nedsatt_arbeidsevne_dato, ytterligere_nedsatt_arbeidsevne_dato, oppdatert_tid) VALUES (?, ?, ?, ?, ?, ?, ?) "
 
         return connection.executeReturnKey(sql) {
             setParams {
+                val oppdatertTid = LocalDateTime.now(clock)
                 setString(1, grunnlag.type().toString())
                 setLong(2, behandlingId.id)
-                setLocalDateTime(3, LocalDateTime.now())
+                setLocalDateTime(3, oppdatertTid)
                 setInt(4, grunnlag.beregningsår().value)
                 setLocalDate(5, grunnlag.nedsattArbeidsevneEllerStudieevneDato())
                 setLocalDate(6, grunnlag.ytterligereNedsattArbeidsevneDato())
+                setLocalDateTime(7, oppdatertTid)
             }
         }
     }
@@ -255,7 +259,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
                 )
                 setInt(c++, beregningsGrunnlag.uføreYtterligereNedsattArbeidsevneÅr)
                 setString(
-                    c++,
+                    c,
                     DefaultJsonMapper.toJson(beregningsGrunnlag.uføreInntekterFraForegåendeÅr.entries.map {
                         ÅrOgInntekt(
                             it.key,

--- a/app/src/main/kotlin/no/nav/aap/statistikk/tilkjentytelse/repository/TilkjentYtelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/tilkjentytelse/repository/TilkjentYtelseRepository.kt
@@ -8,6 +8,7 @@ import no.nav.aap.statistikk.tilkjentytelse.Minstesats
 import no.nav.aap.statistikk.tilkjentytelse.TilkjentYtelse
 import no.nav.aap.statistikk.tilkjentytelse.TilkjentYtelsePeriode
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.*
@@ -15,7 +16,8 @@ import java.util.*
 private val logger = LoggerFactory.getLogger(TilkjentYtelseRepository::class.java)
 
 class TilkjentYtelseRepository(
-    private val dbConnection: DBConnection
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) : ITilkjentYtelseRepository {
     companion object : RepositoryFactory<ITilkjentYtelseRepository> {
         override fun konstruer(connection: DBConnection): ITilkjentYtelseRepository {
@@ -35,12 +37,14 @@ class TilkjentYtelseRepository(
 
         dbConnection.execute(deletePeriodeSql) { setParams { setInt(1, behandlingId) } }
         dbConnection.execute(deleteYtelseSql) { setParams { setInt(1, behandlingId) } }
+        val oppdatertTid = LocalDateTime.now(clock)
 
         val nøkkel =
-            dbConnection.executeReturnKey("INSERT INTO TILKJENT_YTELSE (behandling_id, opprettet_tidspunkt) VALUES (?, ?)") {
+            dbConnection.executeReturnKey("INSERT INTO TILKJENT_YTELSE (behandling_id, opprettet_tidspunkt, oppdatert_tid) VALUES (?, ?, ?)") {
                 setParams {
                     setInt(1, behandlingId)
-                    setLocalDateTime(2, LocalDateTime.now())
+                    setLocalDateTime(2, oppdatertTid)
+                    setLocalDateTime(3, oppdatertTid)
                 }
             }
 

--- a/app/src/main/kotlin/no/nav/aap/statistikk/vilkårsresultat/repository/VilkårsresultatRepository.kt
+++ b/app/src/main/kotlin/no/nav/aap/statistikk/vilkårsresultat/repository/VilkårsresultatRepository.kt
@@ -5,13 +5,15 @@ import no.nav.aap.komponenter.dbconnect.Row
 import no.nav.aap.komponenter.repository.RepositoryFactory
 import no.nav.aap.statistikk.behandling.BehandlingId
 import org.slf4j.LoggerFactory
+import java.time.Clock
 import java.time.LocalDateTime
 import java.util.*
 
 private val log = LoggerFactory.getLogger(VilkårsresultatRepository::class.java)
 
 class VilkårsresultatRepository(
-    private val dbConnection: DBConnection
+    private val dbConnection: DBConnection,
+    private val clock: Clock = Clock.systemDefaultZone(),
 ) : IVilkårsresultatRepository {
     companion object : RepositoryFactory<IVilkårsresultatRepository> {
         override fun konstruer(connection: DBConnection): IVilkårsresultatRepository {
@@ -41,13 +43,15 @@ class VilkårsresultatRepository(
         dbConnection.execute(deletePeriodeSql) { setParams { setLong(1, behandlingId.id) } }
         dbConnection.execute(deleteVilkarSql) { setParams { setLong(1, behandlingId.id) } }
         dbConnection.execute(deleteResultatSql) { setParams { setLong(1, behandlingId.id) } }
+        val oppdatertTid = LocalDateTime.now(clock)
 
         val sqlInsertResultat =
-            """INSERT INTO VILKARSRESULTAT (behandling_id) VALUES (?)"""
+            """INSERT INTO VILKARSRESULTAT (behandling_id, oppdatert_tid) VALUES (?, ?)"""
 
         val uthentetId = dbConnection.executeReturnKey(sqlInsertResultat) {
             setParams {
                 setLong(1, behandlingId.id)
+                setLocalDateTime(2, oppdatertTid)
             }
         }
 
@@ -201,4 +205,3 @@ WHERE vilkar_id = ?;
         }
     }
 }
-

--- a/app/src/main/resources/migrering/V1.103__oppdatert_tid_for_behandling_views.sql
+++ b/app/src/main/resources/migrering/V1.103__oppdatert_tid_for_behandling_views.sql
@@ -1,0 +1,103 @@
+ALTER TABLE diagnose
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+ALTER TABLE rettighetstype
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+UPDATE diagnose d
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling b
+         JOIN behandling_historikk bh ON bh.behandling_id = b.id
+WHERE d.behandling_id = b.id
+  AND bh.gjeldende = TRUE;
+
+UPDATE rettighetstype r
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling b
+         JOIN behandling_historikk bh ON bh.behandling_id = b.id
+WHERE r.behandling_id = b.id
+  AND bh.gjeldende = TRUE;
+
+ALTER TABLE diagnose
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+
+ALTER TABLE rettighetstype
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+
+ALTER TABLE vilkarsresultat
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+ALTER TABLE tilkjent_ytelse
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+ALTER TABLE grunnlag
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+ALTER TABLE samordning_ufore
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+ALTER TABLE samordning_statlig_ytelse
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+ALTER TABLE samordning_avregning_andre_ytelser
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+ALTER TABLE samordning_arbeidsgiver
+    ADD COLUMN oppdatert_tid TIMESTAMP(6);
+
+UPDATE vilkarsresultat vr
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE vr.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE tilkjent_ytelse ty
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE ty.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE grunnlag g
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE g.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE samordning_ufore su
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE su.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE samordning_statlig_ytelse ssy
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE ssy.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE samordning_avregning_andre_ytelser saay
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE saay.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+UPDATE samordning_arbeidsgiver sag
+SET oppdatert_tid = bh.oppdatert_tid
+FROM behandling_historikk bh
+WHERE sag.behandling_id = bh.behandling_id
+  AND bh.gjeldende = TRUE;
+
+ALTER TABLE vilkarsresultat
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+
+ALTER TABLE tilkjent_ytelse
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+
+ALTER TABLE grunnlag
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+
+ALTER TABLE samordning_ufore
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+ALTER TABLE samordning_statlig_ytelse
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+ALTER TABLE samordning_avregning_andre_ytelser
+    ALTER COLUMN oppdatert_tid SET NOT NULL;
+ALTER TABLE samordning_arbeidsgiver
+    ALTER COLUMN oppdatert_tid SET NOT NULL;

--- a/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/RettighetstypeperiodeRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/avsluttetbehandling/RettighetstypeperiodeRepositoryTest.kt
@@ -37,7 +37,6 @@ class RettighetstypeperiodeRepositoryTest {
 
         val res =
             dataSource.transaction { RettighetstypeperiodeRepository(it).hent(behandlingReferanse) }
-
         assertThat(res).hasSize(2)
         assertThat(res).isEqualTo(rettighetstypePerioder)
     }
@@ -84,9 +83,24 @@ class RettighetstypeperiodeRepositoryTest {
         val res = dataSource.transaction {
             RettighetstypeperiodeRepository(it).hent(behandlingReferanse)
         }
+        val antallMedOppdatertTid = dataSource.transaction {
+            it.queryFirst(
+                """
+                    SELECT COUNT(*) AS antall
+                    FROM rettighetstype r
+                    JOIN behandling b ON r.behandling_id = b.id
+                    JOIN behandling_referanse br ON b.referanse_id = br.id
+                    WHERE br.referanse = ? AND r.oppdatert_tid IS NOT NULL
+                """.trimIndent()
+            ) {
+                setParams { setUUID(1, behandlingReferanse) }
+                setRowMapper { row -> row.getInt("antall") }
+            }
+        }
 
         assertThat(res).hasSize(2)
         assertThat(res).isEqualTo(oppdatertedPerioder)
+        assertThat(antallMedOppdatertTid).isEqualTo(1)
 
     }
 

--- a/app/src/test/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImplTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/statistikk/behandling/DiagnoseRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import no.nav.aap.statistikk.testutils.Postgres
 import no.nav.aap.statistikk.testutils.builders.forberedDatabase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 import java.util.*
 import javax.sql.DataSource
 
@@ -29,6 +30,9 @@ class DiagnoseRepositoryImplTest {
         val uthentet = dataSource.transaction {
             DiagnoseRepositoryImpl(it).hentForBehandling(behandlingReferanse)
         }
+        val oppdatertTid = dataSource.transaction {
+            hentOppdatertTid(it, behandlingReferanse)
+        }
 
         assertThat(uthentet).isEqualTo(
             DiagnoseEntity(
@@ -38,6 +42,7 @@ class DiagnoseRepositoryImplTest {
                 bidiagnoser = listOf("PEST", "KOLERA")
             )
         )
+        assertThat(oppdatertTid).isNotNull()
 
     }
 
@@ -47,4 +52,24 @@ class DiagnoseRepositoryImplTest {
     ) = DiagnoseRepositoryImpl(it).lagre(
         diagnoseEntity
     )
+
+    private fun hentOppdatertTid(
+        it: DBConnection,
+        behandlingReferanse: UUID
+    ): LocalDateTime = it.queryFirst(
+        """
+            SELECT d.oppdatert_tid AS oppdatert_tid
+            FROM diagnose d
+            JOIN behandling b ON d.behandling_id = b.id
+            JOIN behandling_referanse br ON b.referanse_id = br.id
+            WHERE br.referanse = ?
+        """.trimIndent()
+    ) {
+        setParams {
+            setUUID(1, behandlingReferanse)
+        }
+        setRowMapper { row ->
+            row.getLocalDateTime("oppdatert_tid")
+        }
+    }
 }

--- a/docs/data-path-api-to-bigquery.md
+++ b/docs/data-path-api-to-bigquery.md
@@ -1,0 +1,161 @@
+# Data path: API to BigQuery
+
+This document describes how data moves from incoming REST calls to BigQuery in `aap-statistikk`.
+
+## 1) Ingestion API (REST)
+
+Incoming events are received over authenticated REST endpoints in `app/src/main/kotlin/no/nav/aap/statistikk/api/mottaStatistikk.kt`.
+
+Main endpoints:
+
+- `/stoppetBehandling` (`StoppetBehandling`)
+- `/oppdatertBehandling` (`StoppetBehandling`)
+- `/oppgave` (`OppgaveHendelse`)
+- `/postmottak` (`DokumentflytStoppetHendelse`)
+- `/tilbakekrevingshendelse` (`TilbakekrevingsbehandlingOppdatertHendelse`)
+
+Each endpoint serializes payload and enqueues a Motor job (`JobbAppender`), then returns `202 Accepted`.
+
+## 2) Async processing via Motor jobs
+
+The app wires jobs in `App.kt` and runs them through Motor.
+
+Important jobs in this path:
+
+- `LagreStoppetHendelseJobb`
+- `LagreAvklaringsbehovHendelseJobb`
+- `LagreSakinfoTilBigQueryJobb`
+- `LagreAvsluttetBehandlingTilBigQueryJobb`
+- `LagreOppgaveHendelseJobb`
+- `LagreOppgaveJobb`
+
+## 3) Domain write path to Postgres
+
+`HendelsesService.prosesserNyHendelse()` is the main orchestrator for `StoppetBehandling`:
+
+1. Finds/creates person and sak
+2. Finds/creates/updates behandling + behandling_historikk
+3. Stores meldekort when present
+4. If status is `AVSLUTTET`, stores extended avsluttet-behandling data
+5. Publishes follow-up internal events that enqueue BigQuery-related jobs
+
+Core source tables (Postgres in this repo, schema `public`) are then replicated to BigQuery dataset `datastream_hendelser` by Datastream.
+
+## 4) Two BigQuery delivery paths
+
+### A. Saksstatistikk path (table -> view in BigQuery)
+
+1. `StatistikkHendelse.SakstatistikkSkalLagres` is published
+2. `LagreSakinfoTilBigQueryJobb` runs `SaksStatistikkService`
+3. Service writes rows to Postgres table `saksstatistikk`
+4. Datastream replicates `public_saksstatistikk` to `datastream_hendelser.public_saksstatistikk`
+5. BigQuery view `saksstatistikk.view_saksstatistikk` exposes the dataset
+
+### B. Ytelsesstatistikk path (views over replicated source tables)
+
+For avsluttede behandlinger, domain tables are persisted in Postgres (for example `behandling_historikk`, `diagnose`, `diagnose_periode`, `rettighetstype`, `tilkjent_ytelse*`, `grunnlag*`, `samordning_*`), then replicated by Datastream to `datastream_hendelser`.
+
+BigQuery views in `ytelsestatistikk` read those replicated tables, including:
+
+- `view_behandlinger`
+- `view_utbetalinger`
+- `view_tilkjent_ytelse`
+- `view_vilkarsresultat`
+- `view_beregningsgrunnlag`
+- `view_samordning`
+
+These views now use persisted `oppdatert_tid` fields from source tables for `endret_tid` / `rad_endret_tid`.
+
+### Manual source-table corrections
+
+Manual corrections in Postgres must update `oppdatert_tid` explicitly in the same transaction as the data change. Some child tables do not have their own `oppdatert_tid`; update the parent or another retained row used by the relevant view instead.
+
+Use one timestamp for the whole correction, so rows changed together get the same `oppdatert_tid`:
+
+```sql
+BEGIN;
+
+WITH oppdatering AS (
+  SELECT CURRENT_TIMESTAMP(6)::timestamp AS oppdatert_tid
+),
+oppdatert_rettighetstype AS (
+  UPDATE rettighetstype r
+  SET oppdatert_tid = oppdatering.oppdatert_tid
+  FROM oppdatering
+  WHERE r.id = (
+    SELECT rp.rettighetstype_id
+    FROM rettighetstypeperioder rp
+    WHERE rp.id = 123
+  )
+  RETURNING r.id
+)
+UPDATE rettighetstypeperioder rp
+SET
+  til_dato = DATE '2026-01-31'
+FROM oppdatert_rettighetstype
+WHERE rp.id = 123
+  AND rp.rettighetstype_id = oppdatert_rettighetstype.id;
+
+COMMIT;
+```
+
+If multiple source tables are corrected together, set `oppdatert_tid` on every changed parent or retained row that is read directly or indirectly by a BigQuery view.
+
+### Manual deletes
+
+BigQuery views only read the current replicated rows. If a joined source row is deleted, the view cannot see the deleted row's old `oppdatert_tid`; `endret_tid` / `rad_endret_tid` may therefore stay unchanged or move back to the next-highest timestamp from remaining rows.
+
+When deleting manually, first update a retained row that is included in the relevant view's `endret_tid` calculation, then delete the rows in the same transaction. For behandling-related data, the safest retained row is normally the current `behandling_historikk` row for the behandling.
+
+```sql
+BEGIN;
+
+WITH oppdatering AS (
+  SELECT CURRENT_TIMESTAMP(6)::timestamp AS oppdatert_tid
+),
+berort_behandling AS (
+  SELECT r.behandling_id
+  FROM rettighetstype r
+  WHERE r.id = 456
+)
+UPDATE behandling_historikk bh
+SET oppdatert_tid = oppdatering.oppdatert_tid
+FROM oppdatering, berort_behandling
+WHERE bh.behandling_id = berort_behandling.behandling_id
+  AND bh.gjeldende = TRUE;
+
+DELETE FROM rettighetstypeperioder
+WHERE rettighetstype_id = 456;
+
+DELETE FROM rettighetstype
+WHERE id = 456;
+
+COMMIT;
+```
+
+For child-row deletes where the parent row remains, updating the parent row can be enough. For example, before deleting from `rettighetstypeperioder`, update the corresponding `rettighetstype.oppdatert_tid`. If the parent row is also deleted, update a higher-level retained row such as current `behandling_historikk`.
+
+## 5) Existing direct-to-BigQuery write path (still present)
+
+The codebase still contains a direct write path through `BQYtelseRepository` (`behandlinger` table in BigQuery), triggered by `LagreAvsluttetBehandlingTilBigQueryJobb`.
+
+That path is separate from the `datastream_hendelser`-based views above.
+
+## 6) Deployment of BigQuery views
+
+View resources under `.nais/bigquery/*.yml` are deployed by `.github/workflows/deploy_bigquery.yml`.
+
+The workflow deploy order matters when one view depends on another.
+
+## 7) End-to-end sketch
+
+```text
+REST API (mottaStatistikk.kt)
+  -> Motor queue (JobbAppender)
+  -> Job executors
+  -> Postgres public tables (source of truth)
+  -> Datastream replication
+  -> BigQuery dataset datastream_hendelser
+  -> BigQuery views (ytelsestatistikk / saksstatistikk)
+  -> Downstream consumers
+```


### PR DESCRIPTION
Splittet ut fra #890.

Endringer:
- legger til og backfiller `oppdatert_tid` på kildetabeller som brukes av ytelsesstatistikk-viewene
- skriver `oppdatert_tid` eksplisitt fra repository-kode
- dokumenterer rutiner for manuelle oppdateringer og sletting

View-endringene ligger i egen PR basert på denne branchen.