### PR TITLE
Forenkle gradle config mtp buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     `kotlin-dsl`
 }
@@ -12,19 +10,3 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0")
 }
-
-kotlin {
-    jvmToolchain(21)
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_4)
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_4)
-    }
-}
-
-// Pass på at når vi kaller JavaExec eller Test tasks så bruker vi samme språk-versjon som vi kompilerer til
-val toolchainLauncher = javaToolchains.launcherFor {
-    languageVersion.set(JavaLanguageVersion.of(21))
-}
-tasks.withType<Test>().configureEach { javaLauncher.set(toolchainLauncher) }
-tasks.withType<JavaExec>().configureEach { javaLauncher.set(toolchainLauncher) }


### PR DESCRIPTION
Det er mer støy enn nytte å deklarere språkversjoner spesifikt for buildSrc, da vi ikke publiserer artefakter fra buildSrc og vi har ikke custom code der, vi har bare config. 

Endringen gjør også alle buildSrc/build.gradle.kts like i alle aap-repoene på dette temaet, som forenkler fremtidige oppdateringer. 

AAP-2194