### PR TITLE
fix(ci): prevent deploy cancellations when merging concurrent PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
       id-token: write
     concurrency:
       group: deploy-dev
+      queue: max
     needs: gradle
     uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
     secrets: inherit
@@ -59,6 +60,7 @@ jobs:
       id-token: write
     concurrency:
       group: deploy-prod
+      queue: max
     needs: dev
     uses: navikt/aap-workflows/.github/workflows/deploy.yml@main
     secrets: inherit


### PR DESCRIPTION
## Problem
When merging several dependabot PRs in quick succession, one of the deploys often fails.

Job-level `concurrency` groups (e.g. `deploy-dev`, `deploy-prod`) used the default `queue: single` behavior, which **cancels a pending run** whenever a newer run is queued in the same group. Each new merge queues a new deploy and cancels the previous one's still-pending deploy job \u2014 showing up as a failed/cancelled deploy.

## Fix
- Add `queue: max` to the `deploy-dev`/`deploy-prod` concurrency groups so queued deploys run sequentially (FIFO) instead of cancelling each other.
- Add/strengthen concurrency groups on kontrakt-publishing jobs to avoid racing semantic-version tag computation across concurrent runs.

`queue: max` requires `cancel-in-progress: false` (the default), which these jobs already use.

Companion PR: https://github.com/navikt/aap-utbetal/pull/596